### PR TITLE
Jetty 9 upgrade

### DIFF
--- a/http-integration/pom.xml
+++ b/http-integration/pom.xml
@@ -74,19 +74,8 @@
     </dependency>
  
     <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty</artifactId>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>servlet-api-2.5</artifactId>
-      <version>6.1.14</version>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.mortbay.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
     </dependency>
   </dependencies>
   

--- a/http-integration/src/main/java/org/apache/directory/server/integration/http/HttpServer.java
+++ b/http-integration/src/main/java/org/apache/directory/server/integration/http/HttpServer.java
@@ -31,8 +31,6 @@ import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -46,13 +44,18 @@ import org.apache.directory.server.core.security.TlsKeyGenerator;
 import org.apache.directory.server.i18n.I18n;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.bouncycastle.jce.provider.X509CertParser;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.ContextHandler;
-import org.mortbay.jetty.nio.SelectChannelConnector;
-import org.mortbay.jetty.security.SslSocketConnector;
-import org.mortbay.jetty.webapp.WebAppContext;
-import org.mortbay.xml.XmlConfiguration;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.xml.XmlConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,7 +172,7 @@ public class HttpServer
 
             if ( httpTransport != null )
             {
-                SelectChannelConnector httpConnector = new SelectChannelConnector();
+                ServerConnector httpConnector = new ServerConnector( jetty );
                 httpConnector.setPort( httpTransport.getPort() );
                 httpConnector.setHost( httpTransport.getAddress() );
                 jetty.addConnector( httpConnector );
@@ -208,24 +211,31 @@ public class HttpServer
                     ks.store( stream, password.toCharArray() );
                 }
 
-                SslSocketConnector httpsConnector = new SslSocketConnector();
+                SslContextFactory sslContextFactory = new SslContextFactory();
+                sslContextFactory.setKeyStoreType( "JKS" );
+                sslContextFactory.setKeyStorePath( ksFile.getAbsolutePath() );
+                sslContextFactory.setKeyStorePassword( password );
+                sslContextFactory.setKeyManagerPassword( password );
+
+                HttpConfiguration httpsConfiguration = new HttpConfiguration();
+                httpsConfiguration.setSecureScheme( "https" );
+                httpsConfiguration.setSecurePort( httpsTransport.getPort() );
+                httpsConfiguration.addCustomizer( new SecureRequestCustomizer() );
+
+                ServerConnector httpsConnector = new ServerConnector( jetty, new SslConnectionFactory( sslContextFactory, "http/1.1" ), new HttpConnectionFactory( httpsConfiguration ) );
                 httpsConnector.setPort( httpsTransport.getPort() );
                 httpsConnector.setHost( httpsTransport.getAddress() );
-                httpsConnector.setKeystoreType( ks.getType() );
-                httpsConnector.setKeystore( ksFile.getAbsolutePath() );
-                httpsConnector.setPassword( password );
-                httpsConnector.setKeyPassword( password );
 
                 jetty.addConnector( httpsConnector );
             }
 
-            List<Handler> handlers = new ArrayList<Handler>();
+            HandlerList handlers = new HandlerList();
             for ( WebApp w : webApps )
             {
                 WebAppContext webapp = new WebAppContext();
                 webapp.setWar( w.getWarFile() );
                 webapp.setContextPath( w.getContextPath() );
-                handlers.add( webapp );
+                handlers.addHandler( webapp );
 
                 webapp.setParentLoaderPriority( true );
             }
@@ -258,13 +268,13 @@ public class HttpServer
                     }
 
                     webapp.setContextPath( "/" + ctxName );
-                    handlers.add( webapp );
+                    handlers.addHandler( webapp );
 
                     webapp.setParentLoaderPriority( true );
                 }
             }
 
-            jetty.setHandlers( handlers.toArray( new Handler[handlers.size()] ) );
+            jetty.setHandler( handlers );
 
             configured = true;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dnsjava.version>2.1.7</dnsjava.version>
     <ehcache.version>2.8.5</ehcache.version>
     <findbugs.annotations.version>1.0.0</findbugs.annotations.version>
-    <jetty.version>6.1.26</jetty.version>
+    <jetty.version>9.2.16.v20160414</jetty.version>
     <junit.version>4.12</junit.version>
     <ldapsdk.version>4.1</ldapsdk.version>
     <log4j.version>1.2.17</log4j.version>
@@ -1220,23 +1220,11 @@
       </dependency>
 
       <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty</artifactId>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-webapp</artifactId>
         <version>${jetty.version}</version>
       </dependency>
     
-      <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>servlet-api-2.5</artifactId>
-        <version>6.1.14</version>
-      </dependency>
-    
-      <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty-util</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-
       <dependency>
         <groupId>findbugs</groupId>
         <artifactId>annotations</artifactId>


### PR DESCRIPTION
Hi,

The embedded HTTP server uses Jetty 6 but this version is no longer supported. Here is a patch to upgrade to Jetty 9.
