### PR TITLE
Upgrade Jetty to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     <dnsjava.version>2.1.8</dnsjava.version>
     <ehcache.version>2.10.4</ehcache.version>
     <findbugs.annotations.version>1.0.0</findbugs.annotations.version>
-    <jetty.version>9.4.5.v20170502</jetty.version>
+    <jetty.version>9.4.14.v20181114</jetty.version>
     <!-- The Jetty bundle exports are using version 9.4.5, not 9.4.5.v20170502... -->
-    <jetty.bundle.version>9.4.5</jetty.bundle.version>
+    <jetty.bundle.version>9.4.14</jetty.bundle.version>
     <junit.version>4.12</junit.version>
     <ldapsdk.version>4.1</ldapsdk.version>
     <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
We should update Jetty, as the version we are using has some security advisories against it.