### PR TITLE
Add missing osgi import org.apache.directory.server.core.api.partition

### DIFF
--- a/interceptor-kerberos/pom.xml
+++ b/interceptor-kerberos/pom.xml
@@ -126,6 +126,7 @@
                 org.apache.directory.api.ldap.model.schema;version=${org.apache.directory.api.version},
                 org.apache.directory.api.util;version=${org.apache.directory.api.version},
                 org.apache.directory.server.core.api;version=${project.version},
+                org.apache.directory.server.core.api.partition;version=${project.version},
                 org.apache.directory.server.core.api.entry;version=${project.version},
                 org.apache.directory.server.core.api.interceptor;version=${project.version},
                 org.apache.directory.server.core.api.interceptor.context;version=${project.version},


### PR DESCRIPTION
The interceptor-kerberos is not having the org.apache.directory.server.core.api.partition package in the Import-Package. But the KeyDerivationInterceptor class has the [directoryService.getPartitionNexus()](https://github.com/apache/directory-server/blob/2a7dc89e3e905fd7ea3ace9a04fac561af594f56/interceptor-kerberos/src/main/java/org/apache/directory/server/core/kerberos/KeyDerivationInterceptor.java#L313 ) method which needs this package import