### PR TITLE
DIRSERVER-2326 Use WildFly security dependency to generate certificates

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -158,6 +158,11 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.security</groupId>
+      <artifactId>wildfly-elytron-x500-cert</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/org/apache/directory/server/core/security/CertificateUtilTest.java
+++ b/core/src/test/java/org/apache/directory/server/core/security/CertificateUtilTest.java
@@ -25,9 +25,9 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.cert.X509Certificate;
 
-import org.junit.Test;
+import javax.security.auth.x500.X500Principal;
 
-import sun.security.x509.X500Name;
+import org.junit.Test;
 
 /**
  * Test for the CertificateUtil class.
@@ -42,7 +42,7 @@ public class CertificateUtilTest
     public void testSelfSignedCertificateCreation() throws IOException, GeneralSecurityException
     {
         // Generate the subject's name
-        X500Name owner = new X500Name( "apacheds", "directory", "apache", "US" );
+        X500Principal owner = new X500Principal( "CN=apacheds,OU=directory,O=apache,C=US" );
         
         
         // generate the asymetric keys
@@ -51,7 +51,7 @@ public class CertificateUtilTest
         KeyPair keyPair = keyPairGenerator.generateKeyPair();
             
 
-        X509Certificate certificate = CertificateUtil.generateSelfSignedCertificate( owner, keyPair, 3650, "SHA256WithECDSA" );
+        X509Certificate certificate = CertificateUtil.generateSelfSignedCertificate( owner, keyPair, 3650, "SHA256withECDSA" );
         System.out.println( certificate );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <wagon.ssh.version>3.3.3</wagon.ssh.version>
     <wagon.ssh.external.version>3.3.3</wagon.ssh.external.version>
     <wrapper.version>3.2.3</wrapper.version>
+    <wildfly-elytron.version>1.12.1.Final</wildfly-elytron.version>
   </properties>
 
   <url>https://directory.apache.org/apacheds/1.5</url>
@@ -1245,6 +1246,12 @@
         <groupId>findbugs</groupId>
         <artifactId>annotations</artifactId>
         <version>${findbugs.annotations.version}</version>
+      </dependency>
+    
+      <dependency>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron-x500-cert</artifactId>
+        <version>${wildfly-elytron.version}</version>
       </dependency>
       
       <dependency>

--- a/server-integ/src/test/java/org/apache/directory/server/ssl/LdapsUpdateCertificateIT.java
+++ b/server-integ/src/test/java/org/apache/directory/server/ssl/LdapsUpdateCertificateIT.java
@@ -117,7 +117,7 @@ public class LdapsUpdateCertificateIT extends AbstractLdapTestUnit
         // create a new certificate
         String newIssuerDN = "new_issuer_dn";
         String newSubjectDN = "new_subject_dn";
-        changeCertificate( ldapServer.getKeystoreFile(), "secret", newIssuerDN, newSubjectDN, 365, "SHA256WithECDSA" );
+        changeCertificate( ldapServer.getKeystoreFile(), "secret", newIssuerDN, newSubjectDN, 365, "SHA256withECDSA" );
 
         // now update the certificate (over the wire)
         getLdapServer().reloadSslContext();

--- a/server-integ/src/test/java/org/apache/directory/server/ssl/StartTlsUpdateCertificateIT.java
+++ b/server-integ/src/test/java/org/apache/directory/server/ssl/StartTlsUpdateCertificateIT.java
@@ -127,7 +127,7 @@ public class StartTlsUpdateCertificateIT extends AbstractLdapTestUnit
         // create a new certificate
         String newIssuerDN = "new_issuer_dn";
         String newSubjectDN = "new_subject_dn";
-        changeCertificate( ldapServer.getKeystoreFile(), "secret", newIssuerDN, newSubjectDN, 365, "SHA256WithECDSA" );
+        changeCertificate( ldapServer.getKeystoreFile(), "secret", newIssuerDN, newSubjectDN, 365, "SHA256withECDSA" );
 
         getLdapServer().reloadSslContext();
 

--- a/service/src/test/java/org/apache/directory/server/UberJarMainTest.java
+++ b/service/src/test/java/org/apache/directory/server/UberJarMainTest.java
@@ -35,6 +35,8 @@ import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import javax.security.auth.x500.X500Principal;
+
 import org.apache.directory.api.ldap.codec.api.SchemaBinaryAttributeDetector;
 import org.apache.directory.api.ldap.model.cursor.EntryCursor;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
@@ -54,8 +56,6 @@ import org.apache.directory.server.core.security.CertificateUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import sun.security.x509.X500Name;
 
 import static org.junit.Assert.assertEquals;
 
@@ -114,12 +114,11 @@ public class UberJarMainTest
             KeyPair keyPair = keyPairGenerator.generateKeyPair();
 
             // Generate the subject's name
-            @SuppressWarnings("restriction")
-            X500Name owner = new X500Name( "apacheds", "directory", "apache", "US" );
+            X500Principal owner = new X500Principal( "CN=apacheds,OU=directory,O=apache,C=US" );
 
             // Create the self-signed certificate
             X509Certificate certificate = CertificateUtil.generateSelfSignedCertificate( owner, keyPair, 365,
-                "SHA256WithECDSA" );
+                "SHA256withECDSA" );
 
             keyStore.setKeyEntry( "apachedsKey", keyPair.getPrivate(), keyStorePassword, new X509Certificate[]
                 { certificate } );

--- a/test-framework/src/main/java/org/apache/directory/server/core/integ/AbstractLdapTestUnit.java
+++ b/test-framework/src/main/java/org/apache/directory/server/core/integ/AbstractLdapTestUnit.java
@@ -30,12 +30,12 @@ import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 
+import javax.security.auth.x500.X500Principal;
+
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.security.CertificateUtil;
 import org.apache.directory.server.kerberos.kdc.KdcServer;
 import org.apache.directory.server.ldap.LdapServer;
-
-import sun.security.x509.X500Name;
 
 
 /**
@@ -43,7 +43,6 @@ import sun.security.x509.X500Name;
  *
  * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
  */
-@SuppressWarnings("restriction")
 public abstract class AbstractLdapTestUnit
 {
     /** The used DirectoryService instance */
@@ -106,10 +105,11 @@ public abstract class AbstractLdapTestUnit
         KeyPair keyPair = keyPairGenerator.generateKeyPair();
         
         // Generate the subject's name
-        X500Name subject = new X500Name( subjectDn, "directory", "apache", "US" );
+        X500Principal subject = new X500Principal( "CN=" + subjectDn + ",OU=directory,O=apache,C=US" );
+        
         
         // Generate the issuer's name
-        X500Name issuer = new X500Name( issuerDn, "directory", "apache", "US" );
+        X500Principal issuer = new X500Principal( "CN=" + issuerDn + ",OU=directory,O=apache,C=US" );
 
         // Create the self-signed certificate
         X509Certificate certificate = CertificateUtil.generateCertificate( subject, issuer, keyPair, days, algorithm );


### PR DESCRIPTION
One of the possible fixes for https://issues.apache.org/jira/browse/DIRSERVER-2326

This one uses WildFly Elytron X509 libraries (+500KB).
Check also another possible solution in #40.