### PR TITLE
DIRSERVER-2328 - CreateAuthenticator annotation trust manager improve…

### DIFF
--- a/core-annotations/src/main/java/org/apache/directory/server/core/annotations/CreateAuthenticator.java
+++ b/core-annotations/src/main/java/org/apache/directory/server/core/annotations/CreateAuthenticator.java
@@ -70,9 +70,9 @@ public @interface CreateAuthenticator
 
 
     /** @return The SSL TrustManager FQCN */
-    String delegateSslTrustManagerFQCN() default "org.apache.directory.ldap.client.api.NoVerificationTrustManager";
+    String delegateSslTrustManagerFQCN() default "";
 
 
     /** @return The startTls TrustManager FQCN */
-    String delegateTlsTrustManagerFQCN() default "org.apache.directory.ldap.client.api.NoVerificationTrustManager";
+    String delegateTlsTrustManagerFQCN() default "";
 }

--- a/server-integ/src/test/java/org/apache/directory/server/operations/bind/DelegatedAuthOverSslIT.java
+++ b/server-integ/src/test/java/org/apache/directory/server/operations/bind/DelegatedAuthOverSslIT.java
@@ -56,7 +56,9 @@ import org.junit.runner.RunWith;
                 type = DelegatingAuthenticator.class,
                 delegatePort = 10201,
                 delegateSsl = true,
-                delegateTls = false) })
+                delegateTls = false,
+                delegateSslTrustManagerFQCN = "org.apache.directory.ldap.client.api.NoVerificationTrustManager"
+                ) })
 @ApplyLdifs(
     {
         // Entry # 1

--- a/server-integ/src/test/java/org/apache/directory/server/operations/bind/DelegatedAuthOverTlsIT.java
+++ b/server-integ/src/test/java/org/apache/directory/server/operations/bind/DelegatedAuthOverTlsIT.java
@@ -56,7 +56,8 @@ import org.junit.runner.RunWith;
                 type = DelegatingAuthenticator.class,
                 delegatePort = 10201,
                 delegateSsl = false,
-                delegateTls = true) })
+                delegateTls = true,
+                delegateTlsTrustManagerFQCN = "org.apache.directory.ldap.client.api.NoVerificationTrustManager") })
 @ApplyLdifs(
     {
         // Entry # 1


### PR DESCRIPTION
…ments

There are two problems with the CreateAuthenticator annotation trust manager configuration:

 - delegateSslTrustManagerFQCN + delegateTlsTrustManagerFQCN default to NoVerificationTrustManager, which is not secure. 
 - These values are not plugged through to the DelegatingAuthenticator, which hard-codes NoVerificationTrustManager.

