### PR TITLE
DIRSERVER-2329 - Replication trust manager improvements

### DIFF
--- a/protocol-ldap/src/main/java/org/apache/directory/server/ldap/replication/ReplicationTrustManager.java
+++ b/protocol-ldap/src/main/java/org/apache/directory/server/ldap/replication/ReplicationTrustManager.java
@@ -62,9 +62,6 @@ public final class ReplicationTrustManager implements X509TrustManager
     /** the X509 certificate parser */
     private static X509CertParser parser = new X509CertParser();
 
-    /** the singleton instance of this trust manager */
-    private static final ReplicationTrustManager INSTANCE = new ReplicationTrustManager();
-
     static
     {
         try
@@ -77,6 +74,9 @@ public final class ReplicationTrustManager implements X509TrustManager
             throw new RuntimeException( e );
         }
     }
+
+    /** the singleton instance of this trust manager */
+    private static final ReplicationTrustManager INSTANCE = new ReplicationTrustManager();
 
     /**
      * Creates a instance of ReplicationTrustManager

--- a/protocol-ldap/src/main/java/org/apache/directory/server/ldap/replication/SyncReplConfiguration.java
+++ b/protocol-ldap/src/main/java/org/apache/directory/server/ldap/replication/SyncReplConfiguration.java
@@ -57,7 +57,7 @@ import org.apache.directory.ldap.client.api.NoVerificationTrustManager;
  *   <li>cookie : the replication cookie</li>
  *   <li>useTls : the connection uses TLS, defaults to true</li>
  *   <li>strictCertVerification : strictly verify the certificate, defaults to true</li>
- *   <li>trustManager : the trustManager to use, defaults to @link{NoVerificationTrustManager}</li>
+ *   <li>trustManager : the trustManager to use, defaults to @link{ReplicationTrustManager}</li>
  *   <li></li>
  * </ul>
  * 
@@ -127,8 +127,8 @@ public class SyncReplConfiguration implements ReplicationConsumerConfig
     /** flag to indicate the use of strict certificate verification, default is true */
     private boolean strictCertVerification = true;
 
-    /** the X509 certificate trust manager used, default value set to {@link NoVerificationTrustManager} */
-    private X509TrustManager trustManager = new NoVerificationTrustManager();
+    /** the X509 certificate trust manager used, default value set to {@link ReplicationTrustManager} */
+    private X509TrustManager trustManager = ReplicationTrustManager.getInstance();
 
     /** flag to indicate if this node is part of a MMR setup, default value is true */
     private boolean mmrMode = true;

--- a/server-annotations/src/main/java/org/apache/directory/server/annotations/CreateConsumer.java
+++ b/server-annotations/src/main/java/org/apache/directory/server/annotations/CreateConsumer.java
@@ -30,7 +30,6 @@ import java.lang.annotation.Target;
 import org.apache.directory.api.ldap.model.constants.LdapConstants;
 import org.apache.directory.api.ldap.model.message.AliasDerefMode;
 import org.apache.directory.api.ldap.model.message.SearchScope;
-import org.apache.directory.ldap.client.api.NoVerificationTrustManager;
 
 
 /**
@@ -55,7 +54,6 @@ import org.apache.directory.ldap.client.api.NoVerificationTrustManager;
  *   <li>chaseReferrals : tells if we chase referrals, defaults to false</li>
  *   <li>useTls : the connection uses TLS, defaults to true</li>
  *   <li>strictCertVerification : strictly verify the certificate, defaults to true</li>
- *   <li>trustManager : the trustManager to use, defaults to @link{NoVerificationTrustManager}</li>
  * </ul>
  * @author <a href="mailto:dev@directory.apache.org">Apache Directory Project</a>
  */
@@ -208,11 +206,4 @@ public @interface CreateConsumer
      */
     boolean strictCertVerification() default true;
 
-
-    /** 
-     * The X509 certificate trust manager used, default value set to {@link NoVerificationTrustManager}
-     * 
-     *  @return The trust manager class
-     */
-    Class<?> trustManager() default NoVerificationTrustManager.class;
 }

--- a/server-annotations/src/main/java/org/apache/directory/server/factory/ServerAnnotationProcessor.java
+++ b/server-annotations/src/main/java/org/apache/directory/server/factory/ServerAnnotationProcessor.java
@@ -271,6 +271,7 @@ public final class ServerAnnotationProcessor
         config.setUseTls( createConsumer.useTls() );
         config.setBaseDn( createConsumer.baseDn() );
         config.setRefreshInterval( createConsumer.refreshInterval() );
+        config.setStrictCertVerification( createConsumer.strictCertVerification() );
 
         consumer.setConfig( config );
 


### PR DESCRIPTION


There are some improvements that should be made regarding trust manager configuration for Replication:

    In ReplicationTrustManager, the static block is not initialized before the constructor (at least in the tests), leading to a NPE.
    SyncReplConfiguration defaults to NoVerificationTrustManager, which is not secure, even though this is inconsistent with the value for strictCertVerification (true)
    The CreateConsumer annotation has a trustManager setting which is not used anywhere
    The ServerAnnotationProcessor does not wire the value for CreateConsumer.strictCertVerification()

