### PR TITLE
DIRSERVER-2330 - StartTlsHandler and LdapsInitializer use NoVerificat…

### DIFF
--- a/i18n/src/main/java/org/apache/directory/server/i18n/I18n.java
+++ b/i18n/src/main/java/org/apache/directory/server/i18n/I18n.java
@@ -784,7 +784,8 @@ public enum I18n
     ERR_747("ERR_747"),
     ERR_748("ERR_748"),
     ERR_749("ERR_749"),
-    ERR_750("ERR_750");
+    ERR_750("ERR_750"),
+    ERR_751("ERR_751");
 
     private static final ResourceBundle ERR_BUNDLE = ResourceBundle
         .getBundle( "org.apache.directory.server.i18n.errors", Locale.ROOT );

--- a/i18n/src/main/resources/org/apache/directory/server/i18n/errors.properties
+++ b/i18n/src/main/resources/org/apache/directory/server/i18n/errors.properties
@@ -772,3 +772,4 @@ ERR_747=Not a valid log file offset  {0}
 ERR_748=Invalid log file bufferSize/ max size is sepcified bufferSize {0} logFileSize {0}
 ERR_749=Log Scanner is already closed
 ERR_750=Log content is invalid
+ERR_751=Invalid TrustManager Class {0}

--- a/protocol-ldap/src/main/java/org/apache/directory/server/ldap/LdapServer.java
+++ b/protocol-ldap/src/main/java/org/apache/directory/server/ldap/LdapServer.java
@@ -21,6 +21,7 @@ package org.apache.directory.server.ldap;
 
 
 import java.io.IOException;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -31,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.directory.api.ldap.codec.api.LdapApiServiceFactory;
 import org.apache.directory.api.ldap.model.constants.Loggers;
@@ -247,6 +250,7 @@ public class LdapServer extends DirectoryBackedService
     private List<ReplicationConsumer> replConsumers;
 
     private KeyManagerFactory keyManagerFactory;
+    private TrustManager[] trustManagers;
 
     /** the time interval between subsequent pings to each replication provider */
     private int pingerSleepTime;
@@ -355,7 +359,7 @@ public class LdapServer extends DirectoryBackedService
      * with a new SslFilter after reloading the keystore.
      *
      * Note: should be called to reload the keystore after changing the digital certificate.
-     * @throws Exception If teh SSLContext can't be reloaded
+     * @throws Exception If the SSLContext can't be reloaded
      */
     public void reloadSslContext() throws Exception
     {
@@ -419,6 +423,13 @@ public class LdapServer extends DirectoryBackedService
         }
 
         keyManagerFactory = CertificateUtil.loadKeyStore( keystoreFile, certificatePassword );
+
+        if ( trustManagers == null )
+        {
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance( TrustManagerFactory.getDefaultAlgorithm() );
+            trustManagerFactory.init( ( KeyStore ) null );
+            trustManagers = trustManagerFactory.getTrustManagers();
+        }
 
         /*
          * The server is now initialized, we can
@@ -1649,6 +1660,18 @@ public class LdapServer extends DirectoryBackedService
         return keyManagerFactory;
     }
 
+    /**
+     * @return the trust managers of the server
+     */
+    public TrustManager[] getTrustManagers()
+    {
+        return trustManagers;
+    }
+
+    public void setTrustManagers( TrustManager[] trustManagers )
+    {
+        this.trustManagers = trustManagers;
+    }
 
     /**
      * @return The maximum allowed size for an incoming PDU

--- a/protocol-ldap/src/main/java/org/apache/directory/server/ldap/handlers/extended/StartTlsHandler.java
+++ b/protocol-ldap/src/main/java/org/apache/directory/server/ldap/handlers/extended/StartTlsHandler.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 
 import org.apache.directory.api.ldap.extras.extended.startTls.StartTlsRequest;
 import org.apache.directory.api.ldap.extras.extended.startTls.StartTlsResponse;
@@ -38,7 +37,6 @@ import org.apache.directory.api.ldap.model.message.ExtendedRequest;
 import org.apache.directory.api.ldap.model.message.ExtendedResponse;
 import org.apache.directory.api.ldap.model.message.LdapResult;
 import org.apache.directory.api.ldap.model.message.ResultCodeEnum;
-import org.apache.directory.ldap.client.api.NoVerificationTrustManager;
 import org.apache.directory.server.i18n.I18n;
 import org.apache.directory.server.ldap.ExtendedOperationHandler;
 import org.apache.directory.server.ldap.LdapServer;
@@ -181,8 +179,8 @@ public class StartTlsHandler implements ExtendedOperationHandler<ExtendedRequest
 
         try
         {
-            sslContext.init( ldapServer.getKeyManagerFactory().getKeyManagers(), new TrustManager[]
-                { new NoVerificationTrustManager() }, new SecureRandom() );
+            sslContext.init( ldapServer.getKeyManagerFactory().getKeyManagers(),
+                    ldapServer.getTrustManagers(), new SecureRandom() );
         }
         catch ( Exception e )
         {

--- a/protocol-ldap/src/main/java/org/apache/directory/server/ldap/handlers/ssl/LdapsInitializer.java
+++ b/protocol-ldap/src/main/java/org/apache/directory/server/ldap/handlers/ssl/LdapsInitializer.java
@@ -24,10 +24,8 @@ import java.security.SecureRandom;
 import java.util.List;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
 
 import org.apache.directory.api.ldap.model.exception.LdapException;
-import org.apache.directory.ldap.client.api.NoVerificationTrustManager;
 import org.apache.directory.server.i18n.I18n;
 import org.apache.directory.server.ldap.LdapServer;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
@@ -66,8 +64,8 @@ public final class LdapsInitializer
         {
             // Initialize the SSLContext to work with our key managers.
             sslCtx = SSLContext.getInstance( "TLS" );
-            sslCtx.init( ldapServer.getKeyManagerFactory().getKeyManagers(), new TrustManager[]
-                { new NoVerificationTrustManager() }, new SecureRandom() );
+            sslCtx.init( ldapServer.getKeyManagerFactory().getKeyManagers(),
+                    ldapServer.getTrustManagers(), new SecureRandom() );
         }
         catch ( Exception e )
         {

--- a/server-annotations/src/main/java/org/apache/directory/server/annotations/CreateLdapServer.java
+++ b/server-annotations/src/main/java/org/apache/directory/server/annotations/CreateLdapServer.java
@@ -106,4 +106,11 @@ public @interface CreateLdapServer
     
     /** @return The service principal, used by GSSAPI. */
     String saslPrincipal() default "ldap/ldap.example.com@EXAMPLE.COM";
+
+    /**
+     * The X509 certificate trust managers used
+     *
+     *  @return The trust manager classes
+     */
+    Class<?>[] trustManagers() default {};
 }

--- a/server-annotations/src/main/java/org/apache/directory/server/factory/ServerAnnotationProcessor.java
+++ b/server-annotations/src/main/java/org/apache/directory/server/factory/ServerAnnotationProcessor.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.net.ssl.TrustManager;
+
 import org.apache.directory.api.ldap.model.constants.SupportedSaslMechanisms;
 import org.apache.directory.api.util.Network;
 import org.apache.directory.api.util.Strings;
@@ -219,6 +221,23 @@ public final class ServerAnnotationProcessor
             }
 
             ldapServer.setSaslRealms( realms );
+
+            if ( createLdapServer.trustManagers() != null && createLdapServer.trustManagers().length > 0 )
+            {
+                TrustManager[] trustManagers = new TrustManager[createLdapServer.trustManagers().length];
+                for ( int i = 0; i < createLdapServer.trustManagers().length; i++ )
+                {
+                    try
+                    {
+                        trustManagers[i] = ( TrustManager ) createLdapServer.trustManagers()[i].newInstance();
+                    }
+                    catch ( InstantiationException | IllegalAccessException e )
+                    {
+                        throw new RuntimeException( I18n.err( I18n.ERR_751, createLdapServer.trustManagers()[i].getName() ), e );
+                    }
+                }
+                ldapServer.setTrustManagers( trustManagers );
+            }
 
             return ldapServer;
         }

--- a/server-integ/src/test/java/org/apache/directory/server/ldap/handlers/sasl/external/ClientCertificateAuthenticationIT.java
+++ b/server-integ/src/test/java/org/apache/directory/server/ldap/handlers/sasl/external/ClientCertificateAuthenticationIT.java
@@ -92,6 +92,10 @@ import static org.junit.Assert.assertTrue;
         saslMechanisms =
                 {
                         @SaslMechanism(name = SupportedSaslMechanisms.EXTERNAL, implClass = CertificateMechanismHandler.class)
+                },
+        trustManagers =
+                {
+                        org.apache.directory.ldap.client.api.NoVerificationTrustManager.class
                 })
 @ApplyLdifs(
         {


### PR DESCRIPTION
…ionTrustManager

StartTlsHandler and LdapsInitializer use NoVerificationTrustManager. Instead they should get the TrustManagers from the LdapServer, and we should have a new annotation in CreateLdapServer to set the TrustManager classes.