### PR TITLE
DIRSERVER-2322: Move tmp directory into instance layout

### DIFF
--- a/core-api/src/main/java/org/apache/directory/server/core/api/InstanceLayout.java
+++ b/core-api/src/main/java/org/apache/directory/server/core/api/InstanceLayout.java
@@ -89,6 +89,7 @@ public class InstanceLayout extends AbstractLayout
     public static final String PARTITIONS_NAME = "partitions";
     private static final String REPL_NAME = "syncrepl-data";
     private static final String CACHE_NAME = "cache";
+    private static final String TMP_NAME = "tmp";
 
     /** Static file names */
     private static final String LOG4J_PROPERTIES = "log4j.properties";
@@ -113,6 +114,9 @@ public class InstanceLayout extends AbstractLayout
 
     /** The cache directory */
     private File cacheDir;
+
+    /** The tmp directory */
+    private File tmpDir;
 
 
     /**
@@ -152,7 +156,8 @@ public class InstanceLayout extends AbstractLayout
                 getLogDirectory(),
                 getPartitionsDirectory(),
                 getRunDirectory(),
-                getCacheDirectory()
+                getCacheDirectory(),
+                getTmpDirectory()
         };
 
         setRequiredDirectories( requiredDirectories );
@@ -211,11 +216,36 @@ public class InstanceLayout extends AbstractLayout
 
 
     /**
-     * @param cacheDir the confDir to set
+     * @param cacheDir the cacheDir to set
      */
     public void setCacheDir( File cacheDir )
     {
         this.cacheDir = cacheDir;
+    }
+
+
+    /**
+     * Gets the 'tmp' directory ('&lt;instance&gt;/tmp').
+     *
+     * @return the 'tmp' directory
+     */
+    public File getTmpDirectory()
+    {
+        if ( tmpDir == null )
+        {
+            tmpDir = new File( getInstanceDirectory(), TMP_NAME );
+        }
+
+        return tmpDir;
+    }
+
+
+    /**
+     * @param tmpDir the tmpDir to set
+     */
+    public void setTmpDir( File tmpDir )
+    {
+        this.tmpDir = tmpDir;
     }
 
 
@@ -407,6 +437,7 @@ public class InstanceLayout extends AbstractLayout
             + "  Instance run dir              : " + getRunDirectory() + "\n"
             + "  Instance partitions dir       : " + getPartitionsDirectory() + "\n"
             + "  Instance replication data dir : " + getReplDirectory() + "\n"
-            + "  Instance cache dir            : " + getCacheDirectory() + "\n";
+            + "  Instance cache dir            : " + getCacheDirectory() + "\n"
+            + "  Instance tmp dir              : " + getTmpDirectory() + "\n";
     }
 }

--- a/installers-maven-plugin/src/main/resources/org/apache/directory/server/installers/bin/install.sh
+++ b/installers-maven-plugin/src/main/resources/org/apache/directory/server/installers/bin/install.sh
@@ -97,6 +97,8 @@ mkdir -p $DEFAULT_INSTANCE_HOME_DIRECTORY/partitions
 verifyExitCode
 mkdir -p $DEFAULT_INSTANCE_HOME_DIRECTORY/run
 verifyExitCode
+mkdir -p $DEFAULT_INSTANCE_HOME_DIRECTORY/tmp
+verifyExitCode
 
 # Filtering default instance wrapper.conf file
 sed -e "s;@installation.directory@;${APACHEDS_HOME_DIRECTORY};" ../instance/wrapper-instance.conf > ../instance/wrapper-instance.conf.tmp

--- a/installers-maven-plugin/src/main/resources/org/apache/directory/server/installers/rpm/apacheds.spec
+++ b/installers-maven-plugin/src/main/resources/org/apache/directory/server/installers/rpm/apacheds.spec
@@ -48,6 +48,7 @@ mkdir -p $RPM_BUILD_ROOT%{adsdata}/default/conf
 mkdir -p $RPM_BUILD_ROOT%{adsdata}/default/log
 mkdir -p $RPM_BUILD_ROOT%{adsdata}/default/partitions
 mkdir -p $RPM_BUILD_ROOT%{adsdata}/default/run
+mkdir -p $RPM_BUILD_ROOT%{adsdata}/default/tmp
 mkdir -p $RPM_BUILD_ROOT/etc/init.d
 
 # Server files
@@ -95,6 +96,7 @@ ${files.libs}
 %{adsdata}/default/log
 %{adsdata}/default/partitions
 %{adsdata}/default/run
+%{adsdata}/default/tmp
 %config %{adsdata}/default/conf/config.ldif
 %config %{adsdata}/default/conf/log4j.properties
 %config %{adsdata}/default/conf/wrapper-instance.conf

--- a/installers-maven-plugin/src/main/resources/org/apache/directory/server/installers/wrapper-installation.conf
+++ b/installers-maven-plugin/src/main/resources/org/apache/directory/server/installers/wrapper-installation.conf
@@ -35,6 +35,7 @@ wrapper.java.additional.2=-Dapacheds.var.dir=${double.quote}%INSTANCE_DIRECTORY%
 wrapper.java.additional.3=-Dapacheds.log.dir=${double.quote}%INSTANCE_DIRECTORY%/log${double.quote}
 wrapper.java.additional.4=-Dapacheds.run.dir=${double.quote}%INSTANCE_DIRECTORY%/run${double.quote}
 wrapper.java.additional.5=-Dapacheds.instance=${double.quote}%INSTANCE%${double.quote}
+wrapper.java.additional.6=-Djava.io.tmpdir=${double.quote}%INSTANCE_DIRECTORY%/tmp${double.quote}
 
 # Initial Java Heap Size (in MB)
 #wrapper.java.initmemory=1024

--- a/installers/src/test/docker/archive.test
+++ b/installers/src/test/docker/archive.test
@@ -73,6 +73,7 @@ fi
 # install required tools
 apt-get -qq update
 apt-get -qq -y install ldap-utils netcat
+java -version
 
 # start
 /opt/${DIRNAME}/bin/apacheds.sh start

--- a/installers/src/test/docker/bin-DIRSERVER-2173.test
+++ b/installers/src/test/docker/bin-DIRSERVER-2173.test
@@ -67,6 +67,7 @@ apt-get -qq -y install ldap-utils netcat
 # set wrapper java path
 echo "" >> /var/lib/${DIRNAME}/default/conf/wrapper-instance.conf
 echo "wrapper.java.command=$JAVA_HOME/bin/java" >> /var/lib/${DIRNAME}/default/conf/wrapper-instance.conf
+java -version
 
 # start
 service ${SERVICE_NAME} start

--- a/installers/src/test/docker/bin.test
+++ b/installers/src/test/docker/bin.test
@@ -66,6 +66,7 @@ apt-get -qq -y install ldap-utils netcat
 # set wrapper java path
 echo "" >> /var/lib/${DIRNAME}/default/conf/wrapper-instance.conf
 echo "wrapper.java.command=$JAVA_HOME/bin/java" >> /var/lib/${DIRNAME}/default/conf/wrapper-instance.conf
+java -version
 
 # start
 service ${SERVICE_NAME} start

--- a/installers/src/test/docker/deb.test
+++ b/installers/src/test/docker/deb.test
@@ -39,6 +39,7 @@ set -x
 apt-get -qq update
 apt-get -qq -y install ldap-utils netcat procps
 command -v java >/dev/null 2>&1 || apt-get -qq -y install default-jre-headless
+java -version
 
 # assert no duplicate files (DIRSERVER-2197)
 test $(dpkg -c /apacheds.deb | sort | uniq -cd | wc -l) -eq 0
@@ -95,6 +96,9 @@ service ${SERVICE_NAME} status || test $? -ne 0
 grep ".*WARN.*admin password.*security breach.*" /var/lib/${DIRNAME}/default/log/apacheds.log
 # assert no error in log
 grep ".*ERROR.*" /var/lib/${DIRNAME}/default/log/apacheds.log && false
+
+# Handle OpenJ9 class sharing
+rm -rf /opt/${DIRNAME}/javasharedresources
 
 # uninstall
 dpkg -P apacheds

--- a/installers/src/test/docker/rpm.test
+++ b/installers/src/test/docker/rpm.test
@@ -40,7 +40,8 @@ wait_for_apacheds() {
 
 # install packages
 yum -y -q install openldap-clients nmap procps
-command -v java >/dev/null 2>&1 || yum -y -q install java-openjdk-headless
+command -v java >/dev/null 2>&1 || yum -y -q install java-latest-openjdk-headless || yum -y -q install java-openjdk-headless
+java -version
 
 # assert no duplicate files (DIRSERVER-2197)
 test $(rpm -qlp /apacheds.rpm | sort | uniq -cd | wc -l) -eq 0

--- a/installers/src/test/docker/run-archive-tests.sh
+++ b/installers/src/test/docker/run-archive-tests.sh
@@ -28,7 +28,7 @@ if [ -f ${TGZ} ]
 then
     echo
     echo
-    echo "Testing tar.gz archive (Debian 9, OpenJDK 8, 64bit)"
+    echo "Testing tar.gz archive (Debian 10, OpenJDK 8, 64bit)"
     docker run -i --rm -h myhostname \
       -v ${TGZ}:/apacheds.tar.gz \
       -v ${TEST_SCRIPTS_DIR}/archive.test:/archive.test \
@@ -42,7 +42,7 @@ if [ -f ${ZIP} ]
 then
     echo
     echo
-    echo "Testing zip archive (Debian 9, OpenJDK 11, 64bit)"
+    echo "Testing zip archive (Debian 10, OpenJDK 11, 64bit)"
     docker run -i --rm -h myhostname \
       -v ${ZIP}:/apacheds.zip \
       -v ${TEST_SCRIPTS_DIR}/archive.test:/archive.test \

--- a/installers/src/test/docker/run-bin-tests.sh
+++ b/installers/src/test/docker/run-bin-tests.sh
@@ -28,7 +28,7 @@ if [ -f ${BIN64} ]
 then
     echo
     echo
-    echo "Testing bin installer (Debian 9, OpenJDK 8, 64bit)"
+    echo "Testing bin installer (Debian 10, OpenJDK 8, 64bit)"
     docker run -i --rm -h myhostname \
       -v ${BIN64}:/apacheds.bin \
       -v ${TEST_SCRIPTS_DIR}/bin.test:/bin.test \
@@ -36,7 +36,7 @@ then
 
     echo
     echo
-    echo "Testing bin installer (DIRSERVER-2173) (Debian 9, OpenJDK 8, 64bit)"
+    echo "Testing bin installer (DIRSERVER-2173) (Debian 10, OpenJDK 8, 64bit)"
     docker run -i --rm -h myhostname \
       -v ${BIN64}:/apacheds.bin \
       -v ${TEST_SCRIPTS_DIR}/bin-DIRSERVER-2173.test:/bin-DIRSERVER-2173.test \

--- a/installers/src/test/docker/run-deb-tests.sh
+++ b/installers/src/test/docker/run-deb-tests.sh
@@ -39,6 +39,6 @@ then
 
     echo
     echo
-    echo "Testing deb package (Ubuntu 18.04, OpenJ9 12, 64bit)"
-    $DOCKER_CMD adoptopenjdk/openjdk12-openj9:slim bash -c "ln -s /opt/java/openjdk/bin/java /usr/bin/java; bash /deb.test"
+    echo "Testing deb package (Ubuntu 20.04, OpenJ9 16, 64bit)"
+    $DOCKER_CMD adoptopenjdk/openjdk16-openj9:slim bash -c "ln -s /opt/java/openjdk/bin/java /usr/bin/java; bash /deb.test"
 fi

--- a/installers/src/test/docker/run-rpm-tests.sh
+++ b/installers/src/test/docker/run-rpm-tests.sh
@@ -34,8 +34,8 @@ then
 
     echo
     echo
-    echo "Testing rpm package (Fedora 29, OpenJDK 12, 64bit)"
-    $DOCKER_CMD fedora:29 bash /rpm.test
+    echo "Testing rpm package (Fedora 34, OpenJDK latest (16+), 64bit)"
+    $DOCKER_CMD fedora:34 bash /rpm.test
 
     echo
     echo


### PR DESCRIPTION
Configure system property `java.io.tmpdir` in the wrapper to point to the instance layout. Fixes issue when running ApacheDS on Windows because the original tempdir doesn't exist. Also updated some installer test docker images and java versions.