### PR TITLE
bugfix: KerberosTime throws ParseException if times with fractions ar…

### DIFF
--- a/kerberos-codec/src/main/java/org/apache/directory/shared/kerberos/KerberosTime.java
+++ b/kerberos-codec/src/main/java/org/apache/directory/shared/kerberos/KerberosTime.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.apache.directory.api.util.GeneralizedTime;
 import org.apache.directory.api.util.Strings;
 
 
@@ -38,19 +39,8 @@ import org.apache.directory.api.util.Strings;
  */
 public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializable
 {
-    /**
-     * 
-     */
+    /** Serial version id */
     private static final long serialVersionUID = -7541256140193748103L;
-
-    /** The UTC timeZone */
-    private static final TimeZone UTC = TimeZone.getTimeZone( "UTC" );
-
-    /** The KerberosTime as a String*/
-    private String date;
-
-    /** The kerberosTime, as a long */
-    private long kerberosTime;
 
     /** Constant for the {@link KerberosTime} "infinity." */
     public static final KerberosTime INFINITY = new KerberosTime( Long.MAX_VALUE );
@@ -65,13 +55,16 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
     public static final int WEEK = MINUTE * 10080;
 
 
+    /** Kerberos generalized time. */
+    private GeneralizedTime generalizedTime;
+
+
     /**
      * Creates a new instance of a KerberosTime object
      */
     public KerberosTime()
     {
-        kerberosTime = ( System.currentTimeMillis() / 1000L ) * 1000L; // drop the ms
-        convertInternal( kerberosTime );
+        generalizedTime = new GeneralizedTime( ( System.currentTimeMillis() / 1000L ) * 1000L ); // drop the ms
     }
 
 
@@ -98,7 +91,7 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public KerberosTime( long date )
     {
-        convertInternal( date );
+        generalizedTime = new GeneralizedTime( date );
     }
 
 
@@ -109,28 +102,7 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public KerberosTime( Date time )
     {
-        kerberosTime = ( time.getTime() / 1000L ) * 1000L; // drop the ms
-        convertInternal( kerberosTime );
-    }
-
-
-    /**
-     * converts the given milliseconds time to seconds and
-     * also formats the time to the generalized form
-     * 
-     * @param date the time in milliseconds
-     */
-    private void convertInternal( long date )
-    {
-        Calendar calendar = Calendar.getInstance( UTC, Locale.ROOT );
-        calendar.setTimeInMillis( date );
-
-        synchronized ( KerberosUtils.UTC_DATE_FORMAT )
-        {
-            this.date = KerberosUtils.UTC_DATE_FORMAT.format( calendar.getTime() );
-        }
-
-        kerberosTime = ( calendar.getTimeInMillis() / 1000L ) * 1000L; // drop the ms
+        generalizedTime = new GeneralizedTime( ( time.getTime() / 1000L ) * 1000L ); // drop the ms
     }
 
 
@@ -141,7 +113,7 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public long getTime()
     {
-        return kerberosTime;
+        return generalizedTime.getTime();
     }
 
 
@@ -152,7 +124,7 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public Date toDate()
     {
-        return new Date( kerberosTime );
+        return generalizedTime.getDate();
     }
 
 
@@ -165,14 +137,7 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public static KerberosTime getTime( String zuluTime ) throws ParseException
     {
-        Date date = null;
-
-        synchronized ( KerberosUtils.UTC_DATE_FORMAT )
-        {
-            date = KerberosUtils.UTC_DATE_FORMAT.parse( zuluTime );
-        }
-
-        return new KerberosTime( date );
+        return new KerberosTime( zuluTime );
     }
 
 
@@ -180,14 +145,9 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      * Sets the date if it's a valid KerberosTime
      * @param date The date to store
      */
-    public void setDate( String date ) throws ParseException
+    public synchronized void setDate( String date ) throws ParseException
     {
-        synchronized ( KerberosUtils.UTC_DATE_FORMAT )
-        {
-            kerberosTime = KerberosUtils.UTC_DATE_FORMAT.parse( date ).getTime();
-        }
-
-        convertInternal( kerberosTime );
+        generalizedTime = new GeneralizedTime( date );
     }
 
 
@@ -196,7 +156,7 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public byte[] getBytes()
     {
-        return Strings.getBytesUtf8( date );
+        return Strings.getBytesUtf8( getDate() );
     }
 
 
@@ -205,14 +165,19 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public String getDate()
     {
-        return date;
+        return generalizedTime.toGeneralizedTime(  
+            GeneralizedTime.Format.YEAR_MONTH_DAY_HOUR_MIN_SEC,
+            GeneralizedTime.FractionDelimiter.DOT, 0,
+            GeneralizedTime.TimeZoneFormat.Z
+        );
     }
 
 
     @Override
     public int hashCode()
     {
-        return ( int ) kerberosTime;
+        // leave out fraction (milliseconds)
+        return ( int ) ( generalizedTime.getTime() / 1000L );
     }
 
 
@@ -231,7 +196,8 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
 
         KerberosTime other = ( KerberosTime ) obj;
 
-        return kerberosTime == other.kerberosTime;
+	// compare without fraction (milliseconds)
+        return generalizedTime.getTime() / 1000L == other.generalizedTime.getTime() / 1000L;
     }
 
 
@@ -244,11 +210,10 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
     public boolean isInClockSkew( long clockSkew )
     {
         // The KerberosTime does not have milliseconds
-        long delta = Math.abs( kerberosTime - System.currentTimeMillis() );
+        long delta = Math.abs( generalizedTime.getTime() - System.currentTimeMillis() );
 
         return delta < clockSkew;
     }
-
 
     /**
      * compares current kerberos time with the given kerberos time
@@ -259,61 +224,7 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public int compareTo( KerberosTime that )
     {
-        final int BEFORE = -1;
-        final int EQUAL = 0;
-        final int AFTER = 1;
-
-        // this optimization is usually worthwhile, and can always be added
-        if ( this == that )
-        {
-            return EQUAL;
-        }
-
-        // primitive numbers follow this form
-        if ( this.kerberosTime < that.kerberosTime )
-        {
-            return BEFORE;
-        }
-
-        if ( this.kerberosTime > that.kerberosTime )
-        {
-            return AFTER;
-        }
-
-        return EQUAL;
-    }
-
-
-    /**
-     * checks if the current kerberos time is less or equal than the given kerberos time
-     * @param ktime the kerberos time against which the current kerberos time needs to be compared
-     * @return true if current kerberos time is less or equal than the given kerberos time, false otherwise
-     */
-    public boolean lessThan( KerberosTime ktime )
-    {
-        return kerberosTime <= ktime.kerberosTime;
-    }
-
-
-    /**
-     * checks if the current kerberos time is greater than the given kerberos time
-     * @param ktime the kerberos time against which the currnet kerberos time needs to be compared
-     * @return true if current kerberos time is greater than the given kerberos time, false otherwise
-     */
-    public boolean greaterThan( KerberosTime ktime )
-    {
-        return kerberosTime > ktime.kerberosTime;
-    }
-
-
-    /**
-     * Returns whether this {@link KerberosTime} is zero.
-     *
-     * @return true if this {@link KerberosTime} is zero.
-     */
-    public boolean isZero()
-    {
-        return kerberosTime == 0;
+        return generalizedTime.compareTo( that.generalizedTime );
     }
 
 
@@ -322,6 +233,6 @@ public class KerberosTime implements Comparable<KerberosTime>, java.io.Serializa
      */
     public String toString()
     {
-        return date;
+        return getDate();
     }
 }

--- a/kerberos-codec/src/main/java/org/apache/directory/shared/kerberos/KerberosUtils.java
+++ b/kerberos-codec/src/main/java/org/apache/directory/shared/kerberos/KerberosUtils.java
@@ -90,16 +90,16 @@ public class KerberosUtils
      */
     private static final Map<String, String> cipherAlgoMap = new LinkedHashMap<>();
 
-    public static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone( "UTC" );
+//    public static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone( "UTC" );
 
     /** Defines a default date format with a "yyyyMMddHHmmss'Z'" pattern */
-    public static final SimpleDateFormat UTC_DATE_FORMAT = new SimpleDateFormat( "yyyyMMddHHmmss'Z'", Locale.ROOT );
+//    public static final SimpleDateFormat UTC_DATE_FORMAT = new SimpleDateFormat( "yyyyMMddHHmmss'Z'", Locale.ROOT );
 
     private static final Set<EncryptionType> oldEncTypes = new HashSet<>();
 
     static
     {
-        UTC_DATE_FORMAT.setTimeZone( UTC_TIME_ZONE );
+//        UTC_DATE_FORMAT.setTimeZone( UTC_TIME_ZONE );
 
         cipherAlgoMap.put( "rc4", "ArcFourHmac" );
         cipherAlgoMap.put( "aes256", "AES256" );
@@ -577,7 +577,7 @@ public class KerberosUtils
             .getStartTime() : ticket.getEncTicketPart().getAuthTime();
 
         KerberosTime now = new KerberosTime();
-        boolean isValidStartTime = startTime.lessThan( now );
+        boolean isValidStartTime = startTime.compareTo( now ) <= 0;
 
         if ( !isValidStartTime || ( ticket.getEncTicketPart().getFlags().isInvalid() && !isValidate ) )
         {
@@ -586,7 +586,7 @@ public class KerberosUtils
         }
 
         // TODO - doesn't take into account skew
-        if ( !ticket.getEncTicketPart().getEndTime().greaterThan( now ) )
+        if ( ticket.getEncTicketPart().getEndTime().compareTo( now ) < 0)
         {
             throw new KerberosException( ErrorType.KRB_AP_ERR_TKT_EXPIRED );
         }

--- a/kerberos-codec/src/test/java/org/apache/directory/server/kerberos/shared/crypto/encryption/CipherTextHandlerTest.java
+++ b/kerberos-codec/src/test/java/org/apache/directory/server/kerberos/shared/crypto/encryption/CipherTextHandlerTest.java
@@ -23,8 +23,10 @@ package org.apache.directory.server.kerberos.shared.crypto.encryption;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.text.SimpleDateFormat;
 import java.text.ParseException;
 import java.util.Date;
+import java.util.Locale;
 
 import javax.security.auth.kerberos.KerberosKey;
 import javax.security.auth.kerberos.KerberosPrincipal;
@@ -98,6 +100,10 @@ public class CipherTextHandlerTest
             ( byte ) 0xfa, ( byte ) 0x93, ( byte ) 0x02, ( byte ) 0xbe, ( byte ) 0x11, ( byte ) 0x14, ( byte ) 0x22,
             ( byte ) 0x65, ( byte ) 0x92, ( byte ) 0xbd, ( byte ) 0xf5, ( byte ) 0x52, ( byte ) 0x9f, ( byte ) 0x94,
             ( byte ) 0x67, ( byte ) 0x10, ( byte ) 0xd2 };
+
+
+    /** Defines a default date format with a "yyyyMMddHHmmss'Z'" pattern */
+    private static final SimpleDateFormat UTC_DATE_FORMAT = new SimpleDateFormat( "yyyyMMddHHmmss'Z'", Locale.ROOT );
 
 
     /**
@@ -306,9 +312,9 @@ public class CipherTextHandlerTest
     {
         Date date = null;
 
-        synchronized ( KerberosUtils.UTC_DATE_FORMAT )
+        synchronized ( UTC_DATE_FORMAT )
         {
-            date = KerberosUtils.UTC_DATE_FORMAT.parse( zuluTime );
+            date = UTC_DATE_FORMAT.parse( zuluTime );
         }
 
         KerberosTime timeStamp = new KerberosTime( date );

--- a/kerberos-codec/src/test/java/org/apache/directory/server/kerberos/shared/keytab/KeytabTest.java
+++ b/kerberos-codec/src/test/java/org/apache/directory/server/kerberos/shared/keytab/KeytabTest.java
@@ -31,7 +31,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.text.SimpleDateFormat;
 
 import javax.crypto.spec.DESKeySpec;
 
@@ -76,6 +78,10 @@ public class KeytabTest
             ( byte ) 0x45, ( byte ) 0xD7, ( byte ) 0x96, ( byte ) 0x79, ( byte ) 0x04, ( byte ) 0x00, ( byte ) 0x03,
             ( byte ) 0x00, ( byte ) 0x08, ( byte ) 0x13, ( byte ) 0xD9, ( byte ) 0x19, ( byte ) 0x98, ( byte ) 0x23,
             ( byte ) 0x8F, ( byte ) 0x9E, ( byte ) 0x31 };
+
+
+    /** Defines a default date format with a "yyyyMMddHHmmss'Z'" pattern */
+    private static final SimpleDateFormat UTC_DATE_FORMAT = new SimpleDateFormat( "yyyyMMddHHmmss'Z'", Locale.ROOT );
 
 
     /**
@@ -162,9 +168,9 @@ public class KeytabTest
         String zuluTime = "20070217235745Z";
         Date date = null;
 
-        synchronized ( KerberosUtils.UTC_DATE_FORMAT )
+        synchronized ( UTC_DATE_FORMAT )
         {
-            date = KerberosUtils.UTC_DATE_FORMAT.parse( zuluTime );
+            date = UTC_DATE_FORMAT.parse( zuluTime );
         }
 
         KerberosTime timeStamp = new KerberosTime( date.getTime() );


### PR DESCRIPTION
…e found in directory

The class "org.apache.directory.shared.kerberos.KerberosTime" states that the time used never uses fractions. The implementation follows this assumption but the assumption is not right. Kerberos uses generalized time (RFC 4517) which can use fractions.

The consequence of the wrong assumption is that a ParseException is thrown if I use for example the Kerberos implementation kerby to generate principals which can have fractions.

In my changes I used the generalized time implementation that is already available in the LDAP client implementation: "org.apache.directory.api.util.GeneralizedTime". I tried to change as few as possible. Therefore I dropped the fractions in internal handling as the old class did but I made it possible that the class now is able to parse Kerberos time that has been written by other tools which can use fractions.