### PR TITLE
change RSA keysize to 2048. 

### DIFF
--- a/core/src/main/java/org/apache/directory/server/core/security/TlsKeyGenerator.java
+++ b/core/src/main/java/org/apache/directory/server/core/security/TlsKeyGenerator.java
@@ -98,7 +98,7 @@ public final class TlsKeyGenerator
      * 
      *    http://www.apache.org/licenses/exports
      */
-    private static final int KEY_SIZE = 1024;
+    private static final int KEY_SIZE = 2048;
     public static final long YEAR_MILLIS = 365L * 24L * 3600L * 1000L;
 
     static

--- a/ldap-client-test/src/test/java/org/apache/directory/shared/client/api/CertificateValidationTest.java
+++ b/ldap-client-test/src/test/java/org/apache/directory/shared/client/api/CertificateValidationTest.java
@@ -104,7 +104,7 @@ public class CertificateValidationTest extends AbstractLdapTestUnit
         Date startDate = new Date();
         Date expiryDate = new Date( System.currentTimeMillis() + TlsKeyGenerator.YEAR_MILLIS );
         String keyAlgo = "RSA";
-        int keySize = 1024;
+        int keySize = 2048;
 
         // generate root CA, self-signed
         String rootCaSubjectDn = issuerDn;

--- a/server-integ/src/test/java/org/apache/directory/server/ldap/handlers/sasl/external/ClientCertificateAuthenticationIT.java
+++ b/server-integ/src/test/java/org/apache/directory/server/ldap/handlers/sasl/external/ClientCertificateAuthenticationIT.java
@@ -137,7 +137,7 @@ public class ClientCertificateAuthenticationIT extends AbstractLdapTestUnit
             Date startDate = new Date();
             Date expiryDate = new Date( System.currentTimeMillis() + TlsKeyGenerator.YEAR_MILLIS );
             String keyAlgo = "RSA";
-            int keySize = 1024;
+            int keySize = 2048;
 
             Entry entry = new DefaultEntry();
             TlsKeyGenerator.addKeyPair( entry, issuerDn, subjectDn, startDate, expiryDate, keyAlgo, keySize, null, false );


### PR DESCRIPTION
Linux systems that use /etc/crypto-policies/back-ends/java.config block any certs less than 2048 these days, so tests and generated certs fail when they are 1024 bits.