### PR TITLE
Reduce scope of junit in service module

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   


### PR DESCRIPTION
JUnit is included in the shaded jar because due to the previous scope of `compile`