### PR TITLE
Update forbidden apis plugin to 3.6

### DIFF
--- a/ldif-partition/pom.xml
+++ b/ldif-partition/pom.xml
@@ -73,6 +73,12 @@
       <groupId>org.apache.directory.api</groupId>
       <artifactId>api-util</artifactId>
     </dependency>
+
+    <!-- annotations needed at compile time -->
+    <dependency>
+      <groupId>de.thetaphi</groupId>
+      <artifactId>forbiddenapis</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/ldif-partition/src/main/java/org/apache/directory/server/core/partition/ldif/SingleFileLdifPartition.java
+++ b/ldif-partition/src/main/java/org/apache/directory/server/core/partition/ldif/SingleFileLdifPartition.java
@@ -28,6 +28,7 @@ import java.io.RandomAccessFile;
 import java.util.Iterator;
 import java.util.UUID;
 
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import org.apache.directory.api.ldap.model.constants.SchemaConstants;
 import org.apache.directory.api.ldap.model.cursor.Cursor;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
@@ -68,7 +69,7 @@ public class SingleFileLdifPartition extends AbstractLdifPartition
     /** the LDIF file holding the partition's data */
     private RandomAccessFile ldifFile;
 
-    /** flag to enable/disable re-writing in-memory partition data back to file, default is set to true */
+    /** flag to enable/disable re-writing `in-memory partition data back to file, default is set to true */
     private volatile boolean enableRewriting = true;
 
     /** flag used internally to detect if partition data was updated in memory but not on disk */
@@ -469,6 +470,7 @@ public class SingleFileLdifPartition extends AbstractLdifPartition
 
 
         @Override
+        @SuppressForbidden // TODO ldifFile.readLine() uses system file encoding
         protected String getLine() throws IOException
         {
             if ( len == 0 )

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dnsjava.version>3.5.3</dnsjava.version>
     <caffeine.version>2.9.3</caffeine.version>
     <findbugs.annotations.version>1.0.0</findbugs.annotations.version>
-    <forbiddenapis.version>2.7</forbiddenapis.version>
+    <forbiddenapis.version>3.6</forbiddenapis.version>
     <hamcrest.version>2.2</hamcrest.version>
     <jetty.version>9.4.53.v20231009</jetty.version>
     <!-- The Jetty bundle exports are using version 9.4.5, not 9.4.5.v20170502... -->
@@ -577,10 +577,10 @@
         <artifactId>forbiddenapis</artifactId>
         <version>${forbiddenapis.version}</version>
         <configuration>
-          <internalRuntimeForbidden>false</internalRuntimeForbidden>
           <failOnUnsupportedJava>true</failOnUnsupportedJava>
           <failOnViolation>true</failOnViolation>
           <bundledSignatures>
+            <bundledSignature>jdk-non-portable</bundledSignature>
             <bundledSignature>jdk-unsafe</bundledSignature>
             <bundledSignature>jdk-deprecated</bundledSignature>
           </bundledSignatures>
@@ -1139,6 +1139,15 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-pool2</artifactId>
         <version>${commons.pool.version}</version>
+      </dependency>
+
+      <!-- forbidden apis annotations -->
+      <!-- needed for compile, but not runtime -->
+      <dependency>
+        <groupId>de.thetaphi</groupId>
+        <artifactId>forbiddenapis</artifactId>
+        <version>${forbiddenapis.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <!-- Test dependencies -->


### PR DESCRIPTION
This version replaces the `internalRuntimeForbidden` flag with a bundle named `jdk-non-portable` The newer version also uncoverd an issue in SingleFileLdifPartition where the RandomAccessFile uses the system file encoding. The error has been suppressed with an annotation for now. Updating the plugin will help ensure other code doesn't creep in.

NOTE: The @SupressForbidden annotation is needed at compile time, but not runtime, so it has been marked provided (as there are reports of some plugins, like the maven-shade-plugin, not excluding "optional" dependencies)