### PR TITLE
Cleanup and remove deprecated compiler flags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,11 +351,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-            <optimize>true</optimize>
-            <showDeprecations>true</showDeprecations>
-            <encoding>ISO-8859-1</encoding>
+            <showDeprecation>true</showDeprecation>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
- `target` and `source` versions are defined in the parent pom as 1.8
- changes the `encoding` of the compiled classes to UTF-8 (to match other project output)
- `optimize` is deprecated, and is now a no-op
- `showDeprecations` should not have the trailing `s`