### PR TITLE
Make supplemental-models and pom.xml UTF8

### DIFF
--- a/core-avl/pom.xml
+++ b/core-avl/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/appended-resources/supplemental-models.xml
+++ b/src/main/appended-resources/supplemental-models.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file

--- a/xdbm-partition/pom.xml
+++ b/xdbm-partition/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
These files were just ascii, but label them as UTF-8 for consistency.
(files were run through `iconv` to make sure there were no character issues)