### PR TITLE
Remove maven-plugin-annotations from dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1232,12 +1232,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.maven.plugin-tools</groupId>
-        <artifactId>maven-plugin-annotations</artifactId>
-        <version>${maven.plugin.tools.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
         <version>${maven.version}</version>


### PR DESCRIPTION
This dependency is defined in ASF Parent Pom,
so not need to redeclare.

Additionally I would like to remove property `maven.plugin.tools.version` from ASF Parent
Prepare for https://issues.apache.org/jira/browse/MPOM-303