### PR TITLE
Unused variable in OperationalAttributeInterceptor.java

### DIFF
--- a/interceptors/operational/src/main/java/org/apache/directory/server/core/operational/OperationalAttributeInterceptor.java
+++ b/interceptors/operational/src/main/java/org/apache/directory/server/core/operational/OperationalAttributeInterceptor.java
@@ -756,7 +756,6 @@ public class OperationalAttributeInterceptor extends BaseInterceptor
                     }
                     else
                     {
-                        ObjectClass topStructural = objectClassArray[0];
 
                         for ( ObjectClass oc : objectClassArray )
                         {


### PR DESCRIPTION
The variable "topStructural", declared on page 759, is not used anywhere