### PR TITLE
Phenomenon: Using other programs to add 10000 users and then deleting…

### DIFF
--- a/core-avl/src/main/java/org/apache/directory/server/core/avltree/AvlTreeImpl.java
+++ b/core-avl/src/main/java/org/apache/directory/server/core/avltree/AvlTreeImpl.java
@@ -294,7 +294,7 @@ public class AvlTreeImpl<K> implements AvlTree<K>
     }
 
 
-    private LinkedAvlNode<K> rotateRight( LinkedAvlNode<K> x )
+    private synchronized LinkedAvlNode<K> rotateRight( LinkedAvlNode<K> x )
     {
         LinkedAvlNode<K> y = x.left;
         x.left = y.right;
@@ -305,7 +305,7 @@ public class AvlTreeImpl<K> implements AvlTree<K>
     }
 
 
-    private LinkedAvlNode<K> rotateLeft( LinkedAvlNode<K> x )
+    private synchronized LinkedAvlNode<K> rotateLeft( LinkedAvlNode<K> x )
     {
         LinkedAvlNode<K> y = x.right;
         x.right = y.left;


### PR DESCRIPTION
… them, there are still users in the cache after deletion, and these users can never be deleted!, His ID was lost in rdnIdx, but the value of parentIdAndRdn. getNbChild() did not decrease.

Problem discovered: In order to balance the tree, there will be multiple left and right rotations, resulting in multiple threads executing methods and confusing assignment, leading to ID loss.