### PR TITLE
Fix log timestamp format.

### DIFF
--- a/service/log4j.properties
+++ b/service/log4j.properties
@@ -27,9 +27,9 @@ log4j.appender.R.MaxFileSize=10MB
 log4j.appender.R.MaxBackupIndex=5
 
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern=[%d{yyyy-mm-dd'T'HH:mm:ss.sssZ}] %p [%c] - %m%n
+log4j.appender.R.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.sssZ}] %p [%c] - %m%n
 
-log4j.appender.stdout.layout.ConversionPattern=[%d{yyyy-mm-dd'T'HH:mm:ss.sssZ}] %p [%c] - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.sssZ}] %p [%c] - %m%n
 
 # to enabled debugging change the root and the below logger levels to debug and restart the server
 log4j.logger.org.apache.directory.server=WARN

--- a/service/log4j.properties
+++ b/service/log4j.properties
@@ -27,9 +27,9 @@ log4j.appender.R.MaxFileSize=10MB
 log4j.appender.R.MaxBackupIndex=5
 
 log4j.appender.R.layout=org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.sssZ}] %p [%c] - %m%n
+log4j.appender.R.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}] %p [%c] - %m%n
 
-log4j.appender.stdout.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.sssZ}] %p [%c] - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}] %p [%c] - %m%n
 
 # to enabled debugging change the root and the below logger levels to debug and restart the server
 log4j.logger.org.apache.directory.server=WARN


### PR DESCRIPTION
The date component of the log timestamp is using minutes for the month value.