### PR TITLE
Correct ResourceBundle reference in I18n message logging function

### DIFF
--- a/i18n/src/main/java/org/apache/directory/server/i18n/I18n.java
+++ b/i18n/src/main/java/org/apache/directory/server/i18n/I18n.java
@@ -636,7 +636,7 @@ public enum I18n
         try
         {
             return err + " "
-                + new MessageFormat( ERR_BUNDLE.getString( err.getErrorCode() ), Locale.ROOT ).format( args );
+                + new MessageFormat( MSG_BUNDLE.getString( err.getErrorCode() ), Locale.ROOT ).format( args );
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
**Title:** Fix incorrect ResourceBundle reference in message logging function

**Description:**

Corrected ResourceBundle reference in message logging function, it was referring to ERR_BUNDLE which fails to load the message logs from Resource causing the printing of default parameters from exception block.


### Error Message I found while using this in one of my project. 
```
java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key MSG_04100_BIND_FAIL
```

Upon investigation, it appears that the function intended to use `MSG_BUNDLE` is incorrectly referencing `ERR_BUNDLE`. After updating the code to use the correct bundle (`MSG_BUNDLE`), the issue was resolved and logging now works as expected.

I’ve included the fix in this PR.
If the original use of `ERR_BUNDLE` is intentional, could someone clarify its intended use case—especially if it's used internally? I'm happy to adjust the fix accordingly if there's a broader context I'm missing.
