### PR TITLE
Startup LDIF directory loading should use deterministic file ordering

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -70,9 +70,12 @@ jobs:
             echo "Could not find root project version in pom.xml" >&2
             exit 1
           fi
+          version_tag="$(printf '%s' "${version}" | sed 's/[^A-Za-z0-9_.-]/-/g')"
           echo "image_name=${image_name}" >> "${GITHUB_OUTPUT}"
           echo "sha_tag=${sha_tag}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "version_tag=${version_tag}" >> "${GITHUB_OUTPUT}"
+          echo "latest_tag=latest" >> "${GITHUB_OUTPUT}"
 
       - name: Build Docker image with Maven
         run: >
@@ -81,11 +84,19 @@ jobs:
           -Dorg.apache.directory.api.version=2.1.8
           -Dapacheds.docker.image=${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}
 
+      - name: Add Docker image tags
+        if: github.event_name != 'pull_request'
+        run: |
+          docker tag \
+            "${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}" \
+            "${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.version_tag }}"
+          docker tag \
+            "${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}" \
+            "${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.latest_tag }}"
+
       - name: Publish Docker image to GHCR
         if: github.event_name != 'pull_request'
-        run: >
-          mvn -B -Pdocker -DskipTests
-          -pl docker-image
-          -Dorg.apache.directory.api.version=2.1.8
-          -Dapacheds.docker.image=${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}
-          io.fabric8:docker-maven-plugin:0.45.1:push
+        run: |
+          docker push "${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}"
+          docker push "${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.version_tag }}"
+          docker push "${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.latest_tag }}"

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Docker Image"
+
+on:
+  push:
+    branches: [ "master" ]
+    tags: [ "v*" ]
+#  pull_request:
+#    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 130
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Use released Apache Directory dependencies
+        run: |
+          sed -i 's|<version>51-SNAPSHOT</version>|<version>51</version>|' pom.xml
+          sed -i 's|<org.apache.directory.api.version>2.1.8-SNAPSHOT</org.apache.directory.api.version>|<org.apache.directory.api.version>2.1.8</org.apache.directory.api.version>|' pom.xml
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: image
+        shell: bash
+        run: |
+          image_name="ghcr.io/${GITHUB_REPOSITORY,,}/apacheds"
+          sha_tag="${GITHUB_SHA::8}"
+          version="$(python3 -c "import xml.etree.ElementTree as ET; ns={'m':'http://maven.apache.org/POM/4.0.0'}; root=ET.parse('pom.xml').getroot(); version=root.find('m:version', ns); print(version.text.strip() if version is not None and version.text else '')")"
+          if [ -z "${version}" ]; then
+            echo "Could not find root project version in pom.xml" >&2
+            exit 1
+          fi
+          echo "image_name=${image_name}" >> "${GITHUB_OUTPUT}"
+          echo "sha_tag=${sha_tag}" >> "${GITHUB_OUTPUT}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build Docker image with Maven
+        run: >
+          mvn -B -Pdocker -DskipTests
+          -pl docker-image -am package
+          -Dorg.apache.directory.api.version=2.1.8
+          -Dapacheds.docker.image=${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}
+
+      - name: Publish Docker image to GHCR
+        if: github.event_name != 'pull_request'
+        run: >
+          mvn -B -Pdocker -DskipTests
+          -pl docker-image
+          -Dorg.apache.directory.api.version=2.1.8
+          -Dapacheds.docker.image=${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}
+          io.fabric8:docker-maven-plugin:0.45.1:push

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -84,6 +84,16 @@ jobs:
           -Dorg.apache.directory.api.version=2.1.8
           -Dapacheds.docker.image=${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}
 
+      - name: Test Docker image with Testcontainers
+        run: |
+          mvn -B -DskipTests \
+            -pl testcontainers -am install \
+            -Dorg.apache.directory.api.version=2.1.8
+          mvn -B \
+            -pl testcontainers test \
+            -Dorg.apache.directory.api.version=2.1.8 \
+            -Dapacheds.docker.image=${{ steps.image.outputs.image_name }}:${{ steps.image.outputs.sha_tag }}
+
       - name: Add Docker image tags
         if: github.event_name != 'pull_request'
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,10 @@ image and publishes a reusable test library. Downstream tests can depend on
 `org.apache.directory.server:apacheds-testcontainers` and use
 `org.apache.directory.server.testcontainers.ApacheDsContainer`.
 
+The library also includes `withActiveDirectoryFixture()`, an LDAP-facing Active
+Directory simulation fixture for common user, group, and computer account
+queries. See `testcontainers/README.md` for its scope and limitations.
+
 Build the image first, then run the module's smoke test with the same tag:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Contributing to Apache Directory Server
+
+Apache Directory Server is built with Maven. Use the Maven wrapper in this
+repository unless you specifically need to test a different Maven version.
+
+## JDK
+
+The project is compiled for Java 8 compatibility:
+
+```xml
+<maven.compiler.release>8</maven.compiler.release>
+<maven.compiler.source>8</maven.compiler.source>
+<maven.compiler.target>8</maven.compiler.target>
+```
+
+For local development, use JDK 21. The GitHub pull request build runs on
+Temurin JDK 21, while Jenkins also exercises newer JDKs. Release/deploy
+configuration still preserves Java 8 compatibility.
+
+Before building, verify the active JDK:
+
+```sh
+java -version
+./mvnw -version
+```
+
+## Local Build
+
+This repository consumes shared Apache Directory build artifacts that are
+published by other Apache Directory repositories:
+
+* `org.apache.directory.project:project` is the parent POM from
+  `apache/directory-project`.
+* `org.apache.directory.api:*` artifacts are from `apache/directory-ldap-api`.
+
+Maven must be able to resolve these artifacts before ApacheDS modules can
+compile. For ordinary local development, prefer released versions available in
+Maven Central, such as parent POM `51` and LDAP API `2.1.8`.
+
+Compile the project:
+
+```sh
+./mvnw clean compile
+```
+
+Run the normal local build:
+
+```sh
+./mvnw clean install
+```
+
+Build without running tests:
+
+```sh
+./mvnw clean install -DskipTests
+```
+
+If the build asks for unavailable LDAP API snapshot artifacts such as
+`org.apache.directory.api:*:2.1.8-SNAPSHOT`, override the dependency version
+with the released LDAP API artifacts:
+
+```sh
+./mvnw clean install -DskipTests -Dorg.apache.directory.api.version=2.1.8
+```
+
+Skip both test compilation and test execution:
+
+```sh
+./mvnw clean install -Dmaven.test.skip=true
+```
+
+Use `-DskipTests` when you want the fastest regular build that still verifies
+test sources compile. Use `-Dmaven.test.skip=true` only when you intentionally
+want to skip all test work.
+
+## Docker
+
+The existing `installers` module has a `docker` profile that copies
+`installers/src/test/docker` into the build output. That profile supports
+installer-related Docker test assets; it is not the ApacheDS server image
+build.
+
+The `docker-image` module builds an ApacheDS image from the `apacheds-service`
+uber jar using the Fabric8 `docker-maven-plugin`:
+
+```sh
+./mvnw -pl docker-image -am -Pdocker package -DskipTests
+```
+
+Set the image name when you want a local development tag:
+
+```sh
+./mvnw -pl docker-image -am -Pdocker package -DskipTests \
+  -Dapacheds.docker.image=apachedirectory/apacheds:local
+```
+
+Use the `docker` profile instead of the short `docker:build` goal from the
+root reactor. Maven does not resolve the Fabric8 plugin prefix unless
+`io.fabric8` is configured as a plugin group in the local Maven settings.
+
+The image exposes LDAP on port `10389` and LDAPS on port `10636`. Runtime data
+is stored under `/var/lib/apacheds`.
+
+Startup LDIF files can be mounted into `/var/lib/apacheds/default/ldif`, or a
+different directory can be selected with `APACHEDS_LDIF_DIR`. The image passes
+that path to the service with `-Dapacheds.ldif.dir`; see
+`docker-image/README.md` for details.
+
+The `testcontainers` module contains Docker-based integration tests for that
+image and publishes a reusable test library. Downstream tests can depend on
+`org.apache.directory.server:apacheds-testcontainers` and use
+`org.apache.directory.server.testcontainers.ApacheDsContainer`.
+
+Build the image first, then run the module's smoke test with the same tag:
+
+```sh
+./mvnw -pl testcontainers -am test \
+  -Dapacheds.docker.image=apachedirectory/apacheds:local
+```
+
+## Security
+
+Before reporting security issues, read `SECURITY.md` and the linked
+`THREAT_MODEL.md`.

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -1,0 +1,76 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# ApacheDS Docker Image
+
+This module builds an ApacheDS server image from the `apacheds-service` uber
+jar. It uses the Fabric8 `docker-maven-plugin` behind the `docker` Maven
+profile.
+
+Build a local image:
+
+```sh
+./mvnw -pl docker-image -am -Pdocker package -DskipTests \
+  -Dapacheds.docker.image=apachedirectory/apacheds:local
+```
+
+Build only the Docker archive without contacting the Docker daemon:
+
+```sh
+./mvnw -pl docker-image -am -Pdocker package -DskipTests \
+  -Ddocker.buildArchiveOnly=true \
+  -Dapacheds.docker.image=apachedirectory/apacheds:local
+```
+
+Run the image:
+
+```sh
+docker run --rm \
+  -p 10389:10389 \
+  -p 10636:10636 \
+  apachedirectory/apacheds:local
+```
+
+The image exposes LDAP on `10389` and LDAPS on `10636`. Instance data is under
+`/var/lib/apacheds/default`, with `/var/lib/apacheds` declared as a volume.
+
+The default admin bind DN is `uid=admin,ou=system` with password `secret`.
+
+## Startup LDIF Import
+
+ApacheDS can load LDIF entries during startup through its built-in test entry
+loader. The Docker image exposes this with `APACHEDS_LDIF_DIR`, which defaults
+to `/var/lib/apacheds/default/ldif`.
+
+Mount one or more `.ldif` files into that directory:
+
+```sh
+docker run --rm \
+  -p 10389:10389 \
+  -v "$PWD/ldif:/var/lib/apacheds/default/ldif:ro" \
+  apachedirectory/apacheds:local
+```
+
+At startup the service reads the directory through the
+`apacheds.ldif.dir` system property and imports the entries before the LDAP
+listener starts.
+
+The Fabric8 plugin output directory is intentionally set to
+`target/docker-build`, while the Docker context is `target/docker`. Keeping
+those paths separate avoids the Docker build archive including itself.

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -52,6 +52,45 @@ The image exposes LDAP on `10389` and LDAPS on `10636`. Instance data is under
 
 The default admin bind DN is `uid=admin,ou=system` with password `secret`.
 
+## Logging
+
+The image uses Log4j 1.x configuration from the instance configuration
+directory:
+
+```text
+/var/lib/apacheds/default/conf/log4j.properties
+```
+
+On first startup, the entrypoint copies the bundled default configuration into
+that path if the file does not already exist. The default configuration logs to
+stdout and to `${apacheds.log.dir}/apacheds-rolling.log`, with these levels:
+
+```properties
+log4j.rootCategory=WARN, stdout, R
+log4j.logger.org.apache.directory.server=WARN
+log4j.logger.org.apache.mina=WARN
+log4j.logger.org.apache.directory.api=FATAL
+```
+
+To change log levels, mount a custom `log4j.properties` over the instance
+configuration file:
+
+```sh
+docker run --rm \
+  -p 10389:10389 \
+  -v "$PWD/log4j.properties:/var/lib/apacheds/default/conf/log4j.properties:ro" \
+  apachedirectory/apacheds:local
+```
+
+For example, set ApacheDS server logs to debug in the mounted file:
+
+```properties
+log4j.logger.org.apache.directory.server=DEBUG
+```
+
+There is no dedicated log-level environment variable. Use a custom
+`log4j.properties` file when the container needs different logging.
+
 ## Startup LDIF Import
 
 ApacheDS can load LDIF entries during startup through its built-in test entry

--- a/docker-image/pom.xml
+++ b/docker-image/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.directory.server</groupId>
+    <artifactId>apacheds-parent</artifactId>
+    <version>2.0.0.AM28-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>apacheds-docker-image</artifactId>
+  <name>ApacheDS Docker Image</name>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apacheds-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-service-jar</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>apacheds-service</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>${project.build.directory}/docker</outputDirectory>
+                  <destFileName>apacheds-service.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-docker-context</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/docker</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/docker</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>${docker.maven.plugin.version}</version>
+        <configuration>
+          <outputDirectory>${project.build.directory}/docker-build</outputDirectory>
+          <images>
+            <image>
+              <name>${apacheds.docker.image}</name>
+              <build>
+                <contextDir>${project.build.directory}/docker</contextDir>
+                <dockerFile>Dockerfile</dockerFile>
+              </build>
+            </image>
+          </images>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>${docker.maven.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>build-docker-image</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/docker-image/src/main/docker/Dockerfile
+++ b/docker-image/src/main/docker/Dockerfile
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM eclipse-temurin:21-jre
+
+ARG APACHEDS_VERSION=${project.version}
+
+LABEL org.opencontainers.image.title="Apache Directory Server" \
+      org.opencontainers.image.version="${APACHEDS_VERSION}" \
+      org.opencontainers.image.description="ApacheDS LDAP directory server"
+
+RUN useradd --system --uid 10001 --home-dir /var/lib/apacheds --create-home apacheds
+
+COPY apacheds-service.jar /opt/apacheds/lib/apacheds-service.jar
+COPY log4j.properties /opt/apacheds/conf/log4j.properties
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh \
+    && mkdir -p /opt/apacheds/conf /opt/apacheds/lib /var/lib/apacheds/default \
+    && chown -R apacheds:apacheds /opt/apacheds /var/lib/apacheds
+
+USER apacheds
+
+ENV APACHEDS_INSTANCE_DIR=/var/lib/apacheds/default \
+    APACHEDS_CONTROLS= \
+    APACHEDS_EXTENDED_OPERATIONS=
+
+VOLUME ["/var/lib/apacheds"]
+
+EXPOSE 10389 10636
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-image/src/main/docker/docker-entrypoint.sh
+++ b/docker-image/src/main/docker/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eu
+
+INSTANCE_DIR="${APACHEDS_INSTANCE_DIR:-/var/lib/apacheds/default}"
+CONF_DIR="${INSTANCE_DIR}/conf"
+LOG_DIR="${INSTANCE_DIR}/log"
+LDIF_DIR="${APACHEDS_LDIF_DIR:-${INSTANCE_DIR}/ldif}"
+
+mkdir -p "${CONF_DIR}" "${INSTANCE_DIR}/partitions" "${LOG_DIR}" "${LDIF_DIR}"
+
+if [ ! -f "${CONF_DIR}/log4j.properties" ]; then
+  cp /opt/apacheds/conf/log4j.properties "${CONF_DIR}/log4j.properties"
+fi
+
+exec java ${JAVA_OPTS:-} \
+  -Dlog4j.configuration="file:${CONF_DIR}/log4j.properties" \
+  -Dapacheds.log.dir="${LOG_DIR}" \
+  -Dapacheds.ldif.dir="${LDIF_DIR}" \
+  -Dapacheds.controls="${APACHEDS_CONTROLS:-}" \
+  -Dapacheds.extendedOperations="${APACHEDS_EXTENDED_OPERATIONS:-}" \
+  -jar /opt/apacheds/lib/apacheds-service.jar \
+  "${INSTANCE_DIR}" "$@"

--- a/docker-image/src/main/docker/log4j.properties
+++ b/docker-image/src/main/docker/log4j.properties
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+log4j.rootCategory=WARN, stdout, R
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}] %p [%c] - %m%n
+
+log4j.appender.R=org.apache.log4j.RollingFileAppender
+log4j.appender.R.File=${apacheds.log.dir}/apacheds-rolling.log
+log4j.appender.R.MaxFileSize=10MB
+log4j.appender.R.MaxBackupIndex=5
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=[%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}] %p [%c] - %m%n
+
+log4j.logger.org.apache.directory.server=WARN
+log4j.logger.org.apache.mina=WARN
+log4j.logger.org.apache.directory.api=FATAL

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <findbugs.annotations.version>1.0.0</findbugs.annotations.version>
     <forbiddenapis.version>3.10</forbiddenapis.version>
     <hamcrest.version>3.0</hamcrest.version>
+    <docker.maven.plugin.version>0.45.1</docker.maven.plugin.version>
     <jetty.version>9.4.58.v20250814</jetty.version>
     <!-- The Jetty bundle exports are using version 9.4.5, not 9.4.5.v20170502... -->
     <jetty.bundle.version>9.4.48</jetty.bundle.version>
@@ -84,12 +85,14 @@
     <slf4j.api.version>1.7.36</slf4j.api.version>
     <slf4j.api.bundleversion>"$«range;[==,=+)»"</slf4j.api.bundleversion>
     <slf4j.log4j12.version>${slf4j.api.version}</slf4j.log4j12.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
     <wagon.ssh.version>3.5.3</wagon.ssh.version>
     <wagon.ssh.external.version>3.5.3</wagon.ssh.external.version>
     <wrapper.version>3.2.3</wrapper.version>
 
     <!-- properties used in tests -->
     <felix.cache.dir>${project.build.directory}/felix-root</felix.cache.dir>
+    <apacheds.docker.image>apachedirectory/apacheds:${project.version}</apacheds.docker.image>
 
     <!-- Properties for the maven plugins -->
     <cyclonedx.version>2.9.1</cyclonedx.version>
@@ -153,6 +156,8 @@
     <module>wrapper</module>
     <module>installers-maven-plugin</module>
     <module>installers</module>
+    <module>docker-image</module>
+    <module>testcontainers</module>
     <!--module>bulkloader</module-->
     <module>osgi-integ</module>
   </modules>

--- a/service-builder/src/main/java/org/apache/directory/server/config/builder/ServiceBuilder.java
+++ b/service-builder/src/main/java/org/apache/directory/server/config/builder/ServiceBuilder.java
@@ -26,6 +26,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -409,6 +410,13 @@ public final class ServiceBuilder
         if ( ldifFile.isDirectory() )
         {
             File[] files = ldifFile.listFiles( ldifFilter );
+
+            if ( files == null )
+            {
+                return;
+            }
+
+            Arrays.sort( files );
 
             for ( File f : files )
             {

--- a/service-builder/src/test/java/org/apache/directory/server/config/builder/ServiceBuilderLdifOrderTest.java
+++ b/service-builder/src/test/java/org/apache/directory/server/config/builder/ServiceBuilderLdifOrderTest.java
@@ -1,0 +1,64 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+package org.apache.directory.server.config.builder;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.junit.jupiter.api.Test;
+
+
+public class ServiceBuilderLdifOrderTest
+{
+    @Test
+    public void testReadTestEntriesLoadsDirectoryFilesInNameOrder() throws Exception
+    {
+        File ldifDirectory = Files.createTempDirectory( "ldif-order" ).toFile();
+
+        Files.write( new File( ldifDirectory, "20-second.ldif" ).toPath(), Arrays.asList(
+            "dn: cn=second,ou=system",
+            "objectClass: person",
+            "objectClass: top",
+            "cn: second",
+            "sn: second",
+            "" ), StandardCharsets.UTF_8 );
+
+        Files.write( new File( ldifDirectory, "10-first.ldif" ).toPath(), Arrays.asList(
+            "dn: cn=first,ou=system",
+            "objectClass: person",
+            "objectClass: top",
+            "cn: first",
+            "sn: first",
+            "" ), StandardCharsets.UTF_8 );
+
+        List<LdifEntry> entries = ServiceBuilder.readTestEntries( ldifDirectory.getAbsolutePath() );
+
+        assertEquals( 2, entries.size() );
+        assertEquals( "cn=first,ou=system", entries.get( 0 ).getDn().getName() );
+        assertEquals( "cn=second,ou=system", entries.get( 1 ).getDn().getName() );
+    }
+}

--- a/service/src/main/java/org/apache/directory/server/ApacheDsService.java
+++ b/service/src/main/java/org/apache/directory/server/ApacheDsService.java
@@ -97,6 +97,9 @@ public class ApacheDsService
     /** A logger for this class */
     private static final Logger LOG = LoggerFactory.getLogger( ApacheDsService.class );
 
+    /** System property used to point to startup LDIF entries. */
+    private static final String PROPERTY_LDIF_DIRECTORY = "apacheds.ldif.dir";
+
     /** The LDAP server instance */
     private LdapServer ldapServer;
 
@@ -360,6 +363,14 @@ public class ApacheDsService
 
         DirectoryService directoryService = ServiceBuilder.createDirectoryService( directoryServiceBean,
             instanceLayout, schemaManager );
+
+        String ldifDirectory = System.getProperty( PROPERTY_LDIF_DIRECTORY );
+
+        if ( ldifDirectory != null && !ldifDirectory.trim().isEmpty() )
+        {
+            LOG.info( "Loading startup LDIF entries from {}", ldifDirectory );
+            directoryService.setTestEntries( ServiceBuilder.readTestEntries( ldifDirectory ) );
+        }
 
         // Inject the DnFactory
         directoryService.setDnFactory( dnFactory );

--- a/testcontainers/README.md
+++ b/testcontainers/README.md
@@ -1,0 +1,58 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# ApacheDS Testcontainers
+
+This module publishes a reusable Testcontainers library for starting ApacheDS
+in downstream integration tests.
+
+```java
+try ( ApacheDsContainer container = new ApacheDsContainer( "apachedirectory/apacheds:local" ) )
+{
+    container.start();
+
+    try ( LdapNetworkConnection connection = container.createAdminConnection() )
+    {
+        Entry rootDse = connection.lookup( Dn.ROOT_DSE );
+    }
+}
+```
+
+## Active Directory Fixture
+
+`withActiveDirectoryFixture()` loads a small LDAP-facing Active Directory
+simulation during container startup:
+
+```java
+try ( ApacheDsContainer container = new ApacheDsContainer( "apachedirectory/apacheds:local" )
+    .withActiveDirectoryFixture() )
+{
+    container.start();
+}
+```
+
+The fixture creates `dc=example,dc=com` entries for users, groups, nested
+membership, and a computer account. It also loads a small compatibility schema
+for common AD attribute names such as `sAMAccountName`, `userPrincipalName`,
+`objectSid`, `objectGUID`, `userAccountControl`, `memberOf`, and `groupType`.
+
+This is intended for applications that need to test AD-style LDAP searches and
+binds. It is not a Microsoft Active Directory Domain Controller emulator: it
+does not implement domain join, Group Policy, DRS replication, Netlogon, SAMR,
+LSA, AD Kerberos extensions, or Windows ACL semantics.

--- a/testcontainers/pom.xml
+++ b/testcontainers/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.directory.server</groupId>
+    <artifactId>apacheds-parent</artifactId>
+    <version>2.0.0.AM28-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>apacheds-testcontainers</artifactId>
+  <name>ApacheDS Testcontainers</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>apacheds-core-constants</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.directory.api</groupId>
+      <artifactId>api-ldap-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.directory.api</groupId>
+      <artifactId>api-ldap-codec-standalone</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.api.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <apacheds.docker.image>${apacheds.docker.image}</apacheds.docker.image>
+            <java.io.tmpdir>${basedir}/target</java.io.tmpdir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/testcontainers/src/main/java/org/apache/directory/server/testcontainers/ApacheDsContainer.java
+++ b/testcontainers/src/main/java/org/apache/directory/server/testcontainers/ApacheDsContainer.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.server.testcontainers;
+
+
+import java.time.Duration;
+
+import org.apache.directory.api.ldap.codec.api.LdapApiServiceFactory;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.ldap.client.api.LdapConnectionConfig;
+import org.apache.directory.ldap.client.api.LdapNetworkConnection;
+import org.apache.directory.server.constants.ServerDNConstants;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+import org.testcontainers.utility.DockerImageName;
+
+
+public class ApacheDsContainer extends GenericContainer<ApacheDsContainer>
+{
+    public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse( "apachedirectory/apacheds" );
+
+    public static final int LDAP_PORT = 10389;
+
+    public static final int LDAPS_PORT = 10636;
+
+    public static final String DEFAULT_ADMIN_DN = ServerDNConstants.ADMIN_SYSTEM_DN;
+
+    public static final String DEFAULT_ADMIN_PASSWORD = "secret";
+
+    public static final String DEFAULT_LDIF_DIRECTORY = "/var/lib/apacheds/default/ldif";
+
+    private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes( 2 );
+
+
+    public ApacheDsContainer()
+    {
+        this( DEFAULT_IMAGE_NAME );
+    }
+
+
+    public ApacheDsContainer( String imageName )
+    {
+        this( DockerImageName.parse( imageName ) );
+    }
+
+
+    public ApacheDsContainer( DockerImageName imageName )
+    {
+        super( imageName.asCompatibleSubstituteFor( DEFAULT_IMAGE_NAME ) );
+        withExposedPorts( LDAP_PORT, LDAPS_PORT );
+        waitingFor( Wait.forListeningPort().withStartupTimeout( DEFAULT_STARTUP_TIMEOUT ) );
+    }
+
+
+    public String getLdapHost()
+    {
+        return getHost();
+    }
+
+
+    public int getLdapPort()
+    {
+        return getMappedPort( LDAP_PORT );
+    }
+
+
+    public int getLdapsPort()
+    {
+        return getMappedPort( LDAPS_PORT );
+    }
+
+
+    public LdapNetworkConnection createAdminConnection() throws Exception
+    {
+        LdapConnectionConfig config = new LdapConnectionConfig();
+        config.setLdapHost( getLdapHost() );
+        config.setLdapPort( getLdapPort() );
+        config.setName( DEFAULT_ADMIN_DN );
+        config.setCredentials( DEFAULT_ADMIN_PASSWORD );
+        config.setLdapApiService( LdapApiServiceFactory.getSingleton() );
+
+        LdapNetworkConnection connection = new LdapNetworkConnection( config );
+        connection.bind( DEFAULT_ADMIN_DN, DEFAULT_ADMIN_PASSWORD );
+        return connection;
+    }
+
+
+    public ApacheDsContainer withLdifClasspathResource( String resourcePath )
+    {
+        String fileName = resourcePath.substring( resourcePath.lastIndexOf( '/' ) + 1 );
+        return withCopyFileToContainer( MountableFile.forClasspathResource( resourcePath ),
+            DEFAULT_LDIF_DIRECTORY + "/" + fileName );
+    }
+
+
+    public ApacheDsContainer withLdifFile( String path )
+    {
+        String fileName = path.substring( Math.max( path.lastIndexOf( '/' ), path.lastIndexOf( '\\' ) ) + 1 );
+        return withCopyFileToContainer( MountableFile.forHostPath( path ), DEFAULT_LDIF_DIRECTORY + "/" + fileName );
+    }
+
+
+    public Entry lookupRootDse() throws Exception
+    {
+        try ( LdapNetworkConnection connection = createAdminConnection() )
+        {
+            return connection.lookup( Dn.ROOT_DSE );
+        }
+    }
+}

--- a/testcontainers/src/main/java/org/apache/directory/server/testcontainers/ApacheDsContainer.java
+++ b/testcontainers/src/main/java/org/apache/directory/server/testcontainers/ApacheDsContainer.java
@@ -36,6 +36,12 @@ import org.testcontainers.utility.DockerImageName;
 
 public class ApacheDsContainer extends GenericContainer<ApacheDsContainer>
 {
+    public static final String ACTIVE_DIRECTORY_SCHEMA_RESOURCE =
+        "org/apache/directory/server/testcontainers/active-directory/00-ad-compat-schema.ldif";
+
+    public static final String ACTIVE_DIRECTORY_FIXTURE_RESOURCE =
+        "org/apache/directory/server/testcontainers/active-directory/10-example-directory.ldif";
+
     public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse( "apachedirectory/apacheds" );
 
     public static final int LDAP_PORT = 10389;
@@ -116,6 +122,13 @@ public class ApacheDsContainer extends GenericContainer<ApacheDsContainer>
     {
         String fileName = path.substring( Math.max( path.lastIndexOf( '/' ), path.lastIndexOf( '\\' ) ) + 1 );
         return withCopyFileToContainer( MountableFile.forHostPath( path ), DEFAULT_LDIF_DIRECTORY + "/" + fileName );
+    }
+
+
+    public ApacheDsContainer withActiveDirectoryFixture()
+    {
+        return withLdifClasspathResource( ACTIVE_DIRECTORY_SCHEMA_RESOURCE )
+            .withLdifClasspathResource( ACTIVE_DIRECTORY_FIXTURE_RESOURCE );
     }
 
 

--- a/testcontainers/src/main/java/org/apache/directory/server/testcontainers/ApacheDsContainer.java
+++ b/testcontainers/src/main/java/org/apache/directory/server/testcontainers/ApacheDsContainer.java
@@ -42,7 +42,8 @@ public class ApacheDsContainer extends GenericContainer<ApacheDsContainer>
     public static final String ACTIVE_DIRECTORY_FIXTURE_RESOURCE =
         "org/apache/directory/server/testcontainers/active-directory/10-example-directory.ldif";
 
-    public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse( "apachedirectory/apacheds" );
+    public static final DockerImageName DEFAULT_IMAGE_NAME =
+        DockerImageName.parse( "ghcr.io/openprojectx/directory-server/apacheds:latest" );
 
     public static final int LDAP_PORT = 10389;
 

--- a/testcontainers/src/main/resources/org/apache/directory/server/testcontainers/active-directory/00-ad-compat-schema.ldif
+++ b/testcontainers/src/main/resources/org/apache/directory/server/testcontainers/active-directory/00-ad-compat-schema.ldif
@@ -1,0 +1,175 @@
+version: 1
+dn: cn=adcompat,ou=schema
+cn: adcompat
+objectclass: metaSchema
+objectclass: top
+m-dependencies: system
+m-dependencies: core
+m-dependencies: cosine
+m-dependencies: inetorgperson
+creatorsname: uid=admin,ou=system
+
+dn: ou=attributeTypes,cn=adcompat,ou=schema
+ou: attributetypes
+objectclass: organizationalUnit
+objectclass: top
+creatorsname: uid=admin,ou=system
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.1,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: TRUE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.1
+m-obsolete: FALSE
+m-description: Active Directory compatible logon name for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+m-usage: USER_APPLICATIONS
+m-name: sAMAccountName
+creatorsname: uid=admin,ou=system
+m-equality: caseIgnoreMatch
+m-substr: caseIgnoreSubstringsMatch
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.2,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: TRUE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.2
+m-obsolete: FALSE
+m-description: Active Directory compatible user principal name for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+m-usage: USER_APPLICATIONS
+m-name: userPrincipalName
+creatorsname: uid=admin,ou=system
+m-equality: caseIgnoreMatch
+m-substr: caseIgnoreSubstringsMatch
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.3,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: TRUE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.3
+m-obsolete: FALSE
+m-description: Active Directory compatible object SID for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+m-usage: USER_APPLICATIONS
+m-name: objectSid
+creatorsname: uid=admin,ou=system
+m-equality: caseExactMatch
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.4,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: TRUE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.4
+m-obsolete: FALSE
+m-description: Active Directory compatible object GUID for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+m-usage: USER_APPLICATIONS
+m-name: objectGUID
+creatorsname: uid=admin,ou=system
+m-equality: caseExactMatch
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.5,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: TRUE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.5
+m-obsolete: FALSE
+m-description: Active Directory compatible account control flags for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.27
+m-usage: USER_APPLICATIONS
+m-name: userAccountControl
+creatorsname: uid=admin,ou=system
+m-equality: integerMatch
+m-ordering: integerOrderingMatch
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.6,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: FALSE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.6
+m-obsolete: FALSE
+m-description: Active Directory compatible memberOf backlink for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.12
+m-usage: USER_APPLICATIONS
+m-name: memberOf
+creatorsname: uid=admin,ou=system
+m-equality: distinguishedNameMatch
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.7,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: TRUE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.7
+m-obsolete: FALSE
+m-description: Active Directory compatible primary group id for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.27
+m-usage: USER_APPLICATIONS
+m-name: primaryGroupID
+creatorsname: uid=admin,ou=system
+m-equality: integerMatch
+m-ordering: integerOrderingMatch
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.1.8,ou=attributeTypes,cn=adcompat,ou=schema
+m-collective: FALSE
+m-singlevalue: TRUE
+m-oid: 1.3.6.1.4.1.18060.0.4.99.1.8
+m-obsolete: FALSE
+m-description: Active Directory compatible group type for LDAP test fixtures
+m-nousermodification: FALSE
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.27
+m-usage: USER_APPLICATIONS
+m-name: groupType
+creatorsname: uid=admin,ou=system
+m-equality: integerMatch
+m-ordering: integerOrderingMatch
+
+dn: ou=objectClasses,cn=adcompat,ou=schema
+ou: objectclasses
+objectclass: organizationalUnit
+objectclass: top
+creatorsname: uid=admin,ou=system
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.99.2.1,ou=objectClasses,cn=adcompat,ou=schema
+m-oid: 1.3.6.1.4.1.18060.0.4.99.2.1
+m-obsolete: FALSE
+m-supobjectclass: top
+m-description: Auxiliary object class for Active Directory compatible LDAP test fixtures
+objectclass: metaObjectClass
+objectclass: metaTop
+objectclass: top
+m-name: activeDirectoryObject
+m-typeobjectclass: AUXILIARY
+creatorsname: uid=admin,ou=system
+m-may: sAMAccountName
+m-may: userPrincipalName
+m-may: objectSid
+m-may: objectGUID
+m-may: userAccountControl
+m-may: memberOf
+m-may: primaryGroupID
+m-may: groupType

--- a/testcontainers/src/main/resources/org/apache/directory/server/testcontainers/active-directory/10-example-directory.ldif
+++ b/testcontainers/src/main/resources/org/apache/directory/server/testcontainers/active-directory/10-example-directory.ldif
@@ -1,0 +1,95 @@
+version: 1
+dn: ou=Users,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: Users
+
+dn: ou=Groups,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: Groups
+
+dn: ou=Computers,dc=example,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: Computers
+
+dn: cn=Alice Adams,ou=Users,dc=example,dc=com
+objectClass: activeDirectoryObject
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Alice Adams
+sn: Adams
+givenName: Alice
+displayName: Alice Adams
+mail: alice.adams@example.com
+uid: aadams
+sAMAccountName: aadams
+userPrincipalName: alice.adams@example.com
+userPassword: secret
+objectSid: S-1-5-21-1000000000-1000000001-1000000002-1101
+objectGUID: 11111111-1111-4111-8111-111111111111
+userAccountControl: 512
+primaryGroupID: 513
+memberOf: cn=Engineering,ou=Groups,dc=example,dc=com
+memberOf: cn=All Staff,ou=Groups,dc=example,dc=com
+
+dn: cn=Bob Brown,ou=Users,dc=example,dc=com
+objectClass: activeDirectoryObject
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Bob Brown
+sn: Brown
+givenName: Bob
+displayName: Bob Brown
+mail: bob.brown@example.com
+uid: bbrown
+sAMAccountName: bbrown
+userPrincipalName: bob.brown@example.com
+userPassword: secret
+objectSid: S-1-5-21-1000000000-1000000001-1000000002-1102
+objectGUID: 22222222-2222-4222-8222-222222222222
+userAccountControl: 514
+primaryGroupID: 513
+memberOf: cn=All Staff,ou=Groups,dc=example,dc=com
+
+dn: cn=Engineering,ou=Groups,dc=example,dc=com
+objectClass: activeDirectoryObject
+objectClass: groupOfNames
+objectClass: top
+cn: Engineering
+description: Engineering users
+sAMAccountName: Engineering
+objectSid: S-1-5-21-1000000000-1000000001-1000000002-2101
+objectGUID: 33333333-3333-4333-8333-333333333333
+groupType: -2147483646
+member: cn=Alice Adams,ou=Users,dc=example,dc=com
+
+dn: cn=All Staff,ou=Groups,dc=example,dc=com
+objectClass: activeDirectoryObject
+objectClass: groupOfNames
+objectClass: top
+cn: All Staff
+description: All employee users
+sAMAccountName: All Staff
+objectSid: S-1-5-21-1000000000-1000000001-1000000002-2102
+objectGUID: 44444444-4444-4444-8444-444444444444
+groupType: -2147483646
+member: cn=Alice Adams,ou=Users,dc=example,dc=com
+member: cn=Bob Brown,ou=Users,dc=example,dc=com
+member: cn=Engineering,ou=Groups,dc=example,dc=com
+
+dn: cn=APP01,ou=Computers,dc=example,dc=com
+objectClass: activeDirectoryObject
+objectClass: device
+objectClass: top
+cn: APP01
+description: Example application server computer object
+sAMAccountName: APP01$
+objectSid: S-1-5-21-1000000000-1000000001-1000000002-3101
+objectGUID: 55555555-5555-4555-8555-555555555555
+userAccountControl: 4096

--- a/testcontainers/src/test/java/org/apache/directory/server/testcontainers/ApacheDsContainerTest.java
+++ b/testcontainers/src/test/java/org/apache/directory/server/testcontainers/ApacheDsContainerTest.java
@@ -27,7 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.directory.api.ldap.codec.api.LdapApiServiceFactory;
 import org.apache.directory.api.ldap.model.cursor.EntryCursor;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.DefaultModification;
@@ -36,6 +39,7 @@ import org.apache.directory.api.ldap.model.entry.ModificationOperation;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.ldap.client.api.LdapConnectionConfig;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.DockerClientFactory;
@@ -184,11 +188,113 @@ class ApacheDsContainerTest
     }
 
 
+    @Test
+    void canLoadActiveDirectoryFixture() throws Exception
+    {
+        try ( ApacheDsContainer container = startActiveDirectoryFixture();
+            LdapNetworkConnection connection = container.createAdminConnection() )
+        {
+            Entry alice = searchSingle( connection, "dc=example,dc=com", "(sAMAccountName=aadams)" );
+            assertEquals( "alice.adams@example.com", alice.get( "userPrincipalName" ).getString() );
+            assertEquals( "S-1-5-21-1000000000-1000000001-1000000002-1101",
+                alice.get( "objectSid" ).getString() );
+            assertEquals( "cn=Engineering,ou=Groups,dc=example,dc=com", alice.get( "memberOf" ).getString() );
+
+            Entry computer = searchSingle( connection, "dc=example,dc=com", "(sAMAccountName=APP01$)" );
+            assertEquals( "4096", computer.get( "userAccountControl" ).getString() );
+        }
+    }
+
+
+    @Test
+    void canSearchActiveDirectoryFixtureGroups() throws Exception
+    {
+        try ( ApacheDsContainer container = startActiveDirectoryFixture();
+            LdapNetworkConnection connection = container.createAdminConnection() )
+        {
+            List<String> directGroups = searchDns( connection, "ou=Groups,dc=example,dc=com",
+                "(member=cn=Alice Adams,ou=Users,dc=example,dc=com)" );
+            assertTrue( directGroups.contains( "cn=Engineering,ou=Groups,dc=example,dc=com" ) );
+            assertTrue( directGroups.contains( "cn=All Staff,ou=Groups,dc=example,dc=com" ) );
+
+            Entry nestedGroup = searchSingle( connection, "ou=Groups,dc=example,dc=com",
+                "(member=cn=Engineering,ou=Groups,dc=example,dc=com)" );
+            assertEquals( "All Staff", nestedGroup.get( "cn" ).getString() );
+        }
+    }
+
+
+    @Test
+    void canBindAsActiveDirectoryFixtureUser() throws Exception
+    {
+        try ( ApacheDsContainer container = startActiveDirectoryFixture();
+            LdapNetworkConnection connection = createConnection( container,
+                "cn=Alice Adams,ou=Users,dc=example,dc=com", "secret" ) )
+        {
+            Entry alice = connection.lookup( "cn=Alice Adams,ou=Users,dc=example,dc=com" );
+            assertNotNull( alice );
+            assertEquals( "aadams", alice.get( "sAMAccountName" ).getString() );
+        }
+    }
+
+
     private ApacheDsContainer startContainer()
     {
         ApacheDsContainer container = newContainer();
         container.start();
         return container;
+    }
+
+
+    private ApacheDsContainer startActiveDirectoryFixture()
+    {
+        ApacheDsContainer container = newContainer().withActiveDirectoryFixture();
+        container.start();
+        return container;
+    }
+
+
+    private Entry searchSingle( LdapNetworkConnection connection, String baseDn, String filter ) throws Exception
+    {
+        try ( EntryCursor cursor = connection.search( baseDn, filter, SearchScope.SUBTREE, "*" ) )
+        {
+            assertTrue( cursor.next() );
+            Entry entry = cursor.get();
+            assertFalse( cursor.next() );
+            return entry;
+        }
+    }
+
+
+    private List<String> searchDns( LdapNetworkConnection connection, String baseDn, String filter ) throws Exception
+    {
+        List<String> dns = new ArrayList<>();
+
+        try ( EntryCursor cursor = connection.search( baseDn, filter, SearchScope.SUBTREE, "cn" ) )
+        {
+            while ( cursor.next() )
+            {
+                dns.add( cursor.get().getDn().getName() );
+            }
+        }
+
+        return dns;
+    }
+
+
+    private LdapNetworkConnection createConnection( ApacheDsContainer container, String bindDn, String password )
+        throws Exception
+    {
+        LdapConnectionConfig config = new LdapConnectionConfig();
+        config.setLdapHost( container.getLdapHost() );
+        config.setLdapPort( container.getLdapPort() );
+        config.setName( bindDn );
+        config.setCredentials( password );
+        config.setLdapApiService( LdapApiServiceFactory.getSingleton() );
+
+        LdapNetworkConnection connection = new LdapNetworkConnection( config );
+        connection.bind( bindDn, password );
+        return connection;
     }
 
 

--- a/testcontainers/src/test/java/org/apache/directory/server/testcontainers/ApacheDsContainerTest.java
+++ b/testcontainers/src/test/java/org/apache/directory/server/testcontainers/ApacheDsContainerTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.directory.server.testcontainers;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.StringReader;
+
+import org.apache.directory.api.ldap.model.cursor.EntryCursor;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.DefaultModification;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.entry.ModificationOperation;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.ldap.client.api.LdapNetworkConnection;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.utility.DockerImageName;
+
+
+class ApacheDsContainerTest
+{
+    @Test
+    void canBindToRootDse() throws Exception
+    {
+        try ( ApacheDsContainer container = startContainer() )
+        {
+            Entry rootDse = container.lookupRootDse();
+            assertNotNull( rootDse );
+        }
+    }
+
+
+    @Test
+    void canImportLdifEntries() throws Exception
+    {
+        try ( ApacheDsContainer container = startContainer();
+            LdapNetworkConnection connection = container.createAdminConnection() )
+        {
+            String ldif = "dn: ou=ldif-smoke,ou=system\n"
+                + "objectClass: organizationalUnit\n"
+                + "objectClass: top\n"
+                + "ou: ldif-smoke\n"
+                + "\n"
+                + "dn: uid=ldif-user,ou=ldif-smoke,ou=system\n"
+                + "objectClass: inetOrgPerson\n"
+                + "objectClass: organizationalPerson\n"
+                + "objectClass: person\n"
+                + "objectClass: top\n"
+                + "cn: LDIF User\n"
+                + "sn: User\n"
+                + "uid: ldif-user\n";
+
+            try ( LdifReader reader = new LdifReader( new StringReader( ldif ) ) )
+            {
+                for ( LdifEntry ldifEntry : reader )
+                {
+                    connection.add( ldifEntry.getEntry() );
+                }
+            }
+
+            Entry imported = connection.lookup( "uid=ldif-user,ou=ldif-smoke,ou=system" );
+            assertNotNull( imported );
+            assertEquals( "LDIF User", imported.get( "cn" ).getString() );
+        }
+    }
+
+
+    @Test
+    void canLoadLdifEntriesAtStartup() throws Exception
+    {
+        try ( ApacheDsContainer container = newContainer().withLdifClasspathResource( "startup-import.ldif" ) )
+        {
+            container.start();
+
+            try ( LdapNetworkConnection connection = container.createAdminConnection() )
+            {
+                Entry imported = connection.lookup( "uid=startup-user,ou=startup-smoke,ou=system" );
+                assertNotNull( imported );
+                assertEquals( "Startup User", imported.get( "cn" ).getString() );
+            }
+        }
+    }
+
+
+    @Test
+    void canCreateReadUpdateAndDeleteEntries() throws Exception
+    {
+        try ( ApacheDsContainer container = startContainer();
+            LdapNetworkConnection connection = container.createAdminConnection() )
+        {
+            connection.add( new DefaultEntry(
+                "ou=crud-smoke,ou=system",
+                "objectClass: organizationalUnit",
+                "objectClass: top",
+                "ou: crud-smoke" ) );
+
+            String userDn = "uid=crud-user,ou=crud-smoke,ou=system";
+            connection.add( new DefaultEntry(
+                userDn,
+                "objectClass: inetOrgPerson",
+                "objectClass: organizationalPerson",
+                "objectClass: person",
+                "objectClass: top",
+                "cn: CRUD User",
+                "sn: User",
+                "uid: crud-user" ) );
+
+            Entry created = connection.lookup( userDn );
+            assertNotNull( created );
+            assertEquals( "CRUD User", created.get( "cn" ).getString() );
+
+            connection.modify( userDn, new DefaultModification( ModificationOperation.ADD_ATTRIBUTE,
+                "description", "updated by smoke test" ) );
+
+            Entry updated = connection.lookup( userDn );
+            assertEquals( "updated by smoke test", updated.get( "description" ).getString() );
+
+            connection.delete( userDn );
+            assertFalse( connection.exists( userDn ) );
+
+            connection.delete( "ou=crud-smoke,ou=system" );
+            assertFalse( connection.exists( "ou=crud-smoke,ou=system" ) );
+        }
+    }
+
+
+    @Test
+    void canSearchImportedEntries() throws Exception
+    {
+        try ( ApacheDsContainer container = startContainer();
+            LdapNetworkConnection connection = container.createAdminConnection() )
+        {
+            connection.add( new DefaultEntry(
+                "ou=search-smoke,ou=system",
+                "objectClass: organizationalUnit",
+                "objectClass: top",
+                "ou: search-smoke" ) );
+
+            connection.add( new DefaultEntry(
+                "uid=search-user,ou=search-smoke,ou=system",
+                "objectClass: inetOrgPerson",
+                "objectClass: organizationalPerson",
+                "objectClass: person",
+                "objectClass: top",
+                "cn: Search User",
+                "sn: User",
+                "uid: search-user" ) );
+
+            try ( EntryCursor cursor = connection.search( "ou=system", "(uid=search-user)",
+                SearchScope.SUBTREE, "uid", "cn" ) )
+            {
+                assertTrue( cursor.next() );
+                Entry found = cursor.get();
+                assertEquals( "search-user", found.get( "uid" ).getString() );
+                assertEquals( "Search User", found.get( "cn" ).getString() );
+                assertFalse( cursor.next() );
+            }
+        }
+    }
+
+
+    private ApacheDsContainer startContainer()
+    {
+        ApacheDsContainer container = newContainer();
+        container.start();
+        return container;
+    }
+
+
+    private ApacheDsContainer newContainer()
+    {
+        assumeTrue( DockerClientFactory.instance().isDockerAvailable(), "Docker is not available" );
+
+        DockerImageName imageName = DockerImageName.parse( System.getProperty( "apacheds.docker.image" ) )
+            .asCompatibleSubstituteFor( "apachedirectory/apacheds" );
+
+        return new ApacheDsContainer( imageName )
+            .withImagePullPolicy( ignored -> false );
+    }
+}

--- a/testcontainers/src/test/resources/log4j.properties
+++ b/testcontainers/src/test/resources/log4j.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %-5p [%c] %m%n

--- a/testcontainers/src/test/resources/startup-import.ldif
+++ b/testcontainers/src/test/resources/startup-import.ldif
@@ -1,0 +1,13 @@
+dn: ou=startup-smoke,ou=system
+objectClass: organizationalUnit
+objectClass: top
+ou: startup-smoke
+
+dn: uid=startup-user,ou=startup-smoke,ou=system
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Startup User
+sn: User
+uid: startup-user


### PR DESCRIPTION
ApacheDS supports loading startup/test LDIF entries from a directory through ServiceBuilder.readTestEntries(...). When the path is a directory, ServiceBuilder.loadEntries(...) currently uses File.listFiles(...) and iterates the returned array directly.

  File.listFiles(...) does not guarantee ordering. This makes startup LDIF import nondeterministic when multiple LDIF files have dependencies between them, for example:

  00-schema.ldif
  10-data.ldif

  In one environment the schema LDIF may load first and startup succeeds. In another environment the data LDIF may load first and entries can fail to import because required schema/object classes/attributes are not available yet.

  Observed Behavior
  Directory LDIF import order can vary by filesystem/environment.
